### PR TITLE
OCE-5: Add creation timestamps to all of the vertices/edges on the graph

### DIFF
--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEEdge.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEEdge.java
@@ -38,11 +38,11 @@ public class CEEdge implements Edge {
     private final long id;
     private InventoryObjectPeerRef peerRef;
     private InventoryObjectRelativeRef relativeRef;
-    private final long timestamp;
+    private final long createdTimestamp;
 
     public CEEdge(long id) {
         this.id = id;
-        timestamp = System.currentTimeMillis();
+        createdTimestamp = System.currentTimeMillis();
     }
 
     public CEEdge(long id, InventoryObjectPeerRef peerRef) {
@@ -71,7 +71,7 @@ public class CEEdge implements Edge {
     }
 
     @Override
-    public long getTimestamp() {
-        return timestamp;
+    public long getCreatedTimestamp() {
+        return createdTimestamp;
     }
 }

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEEdge.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEEdge.java
@@ -38,18 +38,20 @@ public class CEEdge implements Edge {
     private final long id;
     private InventoryObjectPeerRef peerRef;
     private InventoryObjectRelativeRef relativeRef;
+    private final long timestamp;
 
     public CEEdge(long id) {
         this.id = id;
+        timestamp = System.currentTimeMillis();
     }
 
     public CEEdge(long id, InventoryObjectPeerRef peerRef) {
-        this.id = id;
+        this(id);
         this.peerRef = peerRef;
     }
 
     public CEEdge(long id, InventoryObjectRelativeRef relativeRef) {
-        this.id = id;
+        this(id);
         this.relativeRef = relativeRef;
     }
 
@@ -66,5 +68,10 @@ public class CEEdge implements Edge {
     @Override
     public Optional<InventoryObjectRelativeRef> getInventoryObjectRelativeRef() {
         return Optional.ofNullable(relativeRef);
+    }
+
+    @Override
+    public long getTimestamp() {
+        return timestamp;
     }
 }

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEVertex.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEVertex.java
@@ -50,7 +50,8 @@ public class CEVertex implements Vertex {
     private final InventoryObject inventoryObject;
     private final ResourceKey resourceKey;
     private final Map<String, Alarm> alarmsById = new LinkedHashMap<>();
-    private long timestamp;
+    private final long createdTimestamp;
+    private long updatedTimestamp;
 
     public CEVertex(long id, ResourceKey resourceKey) {
         this(id, resourceKey, null);
@@ -60,7 +61,8 @@ public class CEVertex implements Vertex {
         this.id = id;
         this.resourceKey = Objects.requireNonNull(resourceKey);
         this.inventoryObject = inventoryObject;
-        updateTimestamp();
+        createdTimestamp = System.currentTimeMillis();
+        updatedTimestamp = createdTimestamp;
     }
 
     public ResourceKey getResourceKey() {
@@ -69,11 +71,7 @@ public class CEVertex implements Vertex {
 
     public void addOrUpdateAlarm(Alarm alarm) {
         alarmsById.put(alarm.getId(), alarm);
-        updateTimestamp();
-    }
-    
-    private void updateTimestamp() {
-        timestamp = System.currentTimeMillis();
+        updatedTimestamp = System.currentTimeMillis();
     }
 
     @Override
@@ -92,8 +90,13 @@ public class CEVertex implements Vertex {
     }
 
     @Override
-    public long getTimestamp() {
-        return timestamp;
+    public long getCreatedTimestamp() {
+        return createdTimestamp;
+    }
+
+    @Override
+    public long getUpdatedTimestamp() {
+        return updatedTimestamp;
     }
 
     public long getNumericId() {

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEVertex.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/CEVertex.java
@@ -50,6 +50,7 @@ public class CEVertex implements Vertex {
     private final InventoryObject inventoryObject;
     private final ResourceKey resourceKey;
     private final Map<String, Alarm> alarmsById = new LinkedHashMap<>();
+    private long timestamp;
 
     public CEVertex(long id, ResourceKey resourceKey) {
         this(id, resourceKey, null);
@@ -59,6 +60,7 @@ public class CEVertex implements Vertex {
         this.id = id;
         this.resourceKey = Objects.requireNonNull(resourceKey);
         this.inventoryObject = inventoryObject;
+        updateTimestamp();
     }
 
     public ResourceKey getResourceKey() {
@@ -67,6 +69,11 @@ public class CEVertex implements Vertex {
 
     public void addOrUpdateAlarm(Alarm alarm) {
         alarmsById.put(alarm.getId(), alarm);
+        updateTimestamp();
+    }
+    
+    private void updateTimestamp() {
+        timestamp = System.currentTimeMillis();
     }
 
     @Override
@@ -82,6 +89,11 @@ public class CEVertex implements Vertex {
     @Override
     public String getId() {
         return Long.toString(id);
+    }
+
+    @Override
+    public long getTimestamp() {
+        return timestamp;
     }
 
     public long getNumericId() {

--- a/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Edge.java
+++ b/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Edge.java
@@ -46,6 +46,6 @@ public interface Edge {
      * 
      * @return the timestamp
      */
-    long getTimestamp();
+    long getCreatedTimestamp();
 
 }

--- a/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Edge.java
+++ b/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Edge.java
@@ -41,4 +41,11 @@ public interface Edge {
 
     Optional<InventoryObjectRelativeRef> getInventoryObjectRelativeRef();
 
+    /**
+     * Gets the timestamp of when this edge was created.
+     * 
+     * @return the timestamp
+     */
+    long getTimestamp();
+
 }

--- a/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Vertex.java
+++ b/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Vertex.java
@@ -42,4 +42,11 @@ public interface Vertex {
 
     Optional<InventoryObject> getInventoryObject();
 
+    /**
+     * Gets the timestamp of when this vertex was created or last updated.
+     * 
+     * @return the timestamp
+     */
+    long getTimestamp();
+
 }

--- a/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Vertex.java
+++ b/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/Vertex.java
@@ -43,10 +43,17 @@ public interface Vertex {
     Optional<InventoryObject> getInventoryObject();
 
     /**
-     * Gets the timestamp of when this vertex was created or last updated.
+     * Gets the timestamp of when this vertex was created.
      * 
      * @return the timestamp
      */
-    long getTimestamp();
+    long getCreatedTimestamp();
+
+    /**
+     * Gets the timestamp of when this vertex was last updated.
+     *
+     * @return the timestamp
+     */
+    long getUpdatedTimestamp();
 
 }

--- a/features/graph/common/src/main/java/org/opennms/oce/features/graph/common/GraphMLConverter.java
+++ b/features/graph/common/src/main/java/org/opennms/oce/features/graph/common/GraphMLConverter.java
@@ -76,6 +76,8 @@ public class GraphMLConverter {
     private static final String ONMS_ICON_REDUCTION_KEY = "reduction_key";
     private static final String ONMS_ICON_IP_SERVICE = "IP_service";
 
+    private static final String TIMESTAMP_KEY="timestamp";
+
     private GraphMLConverter(Graph<Vertex,Edge> g, List<Incident> incidents) {
         this.g = Objects.requireNonNull(g);
         this.incidents = Objects.requireNonNull(incidents);
@@ -125,6 +127,7 @@ public class GraphMLConverter {
     private void handleVertex(Vertex v) {
         final GraphMLNode node = new GraphMLNode();
         node.setId(getVertexIdFor(v));
+        node.setProperty(TIMESTAMP_KEY, v.getTimestamp());
         v.getInventoryObject().ifPresent(io -> {
             if (io.getFriendlyName() != null) {
                 node.setProperty(ONMS_GRAPHML_LABEL, io.getFriendlyName());
@@ -182,6 +185,7 @@ public class GraphMLConverter {
     private void handleEdge(Edge e) {
         GraphMLEdge edge = new GraphMLEdge();
         edge.setId(e.getId());
+        edge.setProperty(TIMESTAMP_KEY, e.getTimestamp());
         e.getInventoryObjectPeerRef().ifPresent(peerRef ->  edge.setProperty(ONMS_GRAPHML_LABEL, "peer reference"));
         e.getInventoryObjectRelativeRef().ifPresent(relativeRef ->  edge.setProperty(ONMS_GRAPHML_LABEL, "relative reference"));
 

--- a/features/graph/common/src/main/java/org/opennms/oce/features/graph/common/GraphMLConverter.java
+++ b/features/graph/common/src/main/java/org/opennms/oce/features/graph/common/GraphMLConverter.java
@@ -29,7 +29,6 @@
 package org.opennms.oce.features.graph.common;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -39,7 +38,6 @@ import java.util.Objects;
 
 import org.opennms.oce.datasource.api.Alarm;
 import org.opennms.oce.datasource.api.Incident;
-import org.opennms.oce.datasource.api.InventoryObject;
 import org.opennms.oce.features.graph.api.Edge;
 import org.opennms.oce.features.graph.api.OceGraph;
 import org.opennms.oce.features.graph.api.Vertex;
@@ -76,7 +74,8 @@ public class GraphMLConverter {
     private static final String ONMS_ICON_REDUCTION_KEY = "reduction_key";
     private static final String ONMS_ICON_IP_SERVICE = "IP_service";
 
-    private static final String TIMESTAMP_KEY="timestamp";
+    private static final String CREATED_TIMESTAMP_KEY = "createdTimestamp";
+    private static final String UPDATED_TIMESTAMP_KEY = "updatedTimestamp";
 
     private GraphMLConverter(Graph<Vertex,Edge> g, List<Incident> incidents) {
         this.g = Objects.requireNonNull(g);
@@ -127,7 +126,8 @@ public class GraphMLConverter {
     private void handleVertex(Vertex v) {
         final GraphMLNode node = new GraphMLNode();
         node.setId(getVertexIdFor(v));
-        node.setProperty(TIMESTAMP_KEY, v.getTimestamp());
+        node.setProperty(CREATED_TIMESTAMP_KEY, v.getCreatedTimestamp());
+        node.setProperty(UPDATED_TIMESTAMP_KEY, v.getUpdatedTimestamp());
         v.getInventoryObject().ifPresent(io -> {
             if (io.getFriendlyName() != null) {
                 node.setProperty(ONMS_GRAPHML_LABEL, io.getFriendlyName());
@@ -185,7 +185,7 @@ public class GraphMLConverter {
     private void handleEdge(Edge e) {
         GraphMLEdge edge = new GraphMLEdge();
         edge.setId(e.getId());
-        edge.setProperty(TIMESTAMP_KEY, e.getTimestamp());
+        edge.setProperty(CREATED_TIMESTAMP_KEY, e.getCreatedTimestamp());
         e.getInventoryObjectPeerRef().ifPresent(peerRef ->  edge.setProperty(ONMS_GRAPHML_LABEL, "peer reference"));
         e.getInventoryObjectRelativeRef().ifPresent(relativeRef ->  edge.setProperty(ONMS_GRAPHML_LABEL, "relative reference"));
 

--- a/features/graph/common/src/test/java/org/opennms/oce/features/graph/common/GraphMLConversionTest.java
+++ b/features/graph/common/src/test/java/org/opennms/oce/features/graph/common/GraphMLConversionTest.java
@@ -151,11 +151,13 @@ public class GraphMLConversionTest {
     private static class MyVertex implements Vertex {
         private final String id;
         private List<Alarm> alarms = new ArrayList<>();
-        private final long timestamp;
+        private final long createdTimestamp;
+        private long updatedTimestamp;
 
         MyVertex(String id) {
             this.id = Objects.requireNonNull(id);
-            timestamp = System.currentTimeMillis();
+            createdTimestamp = System.currentTimeMillis();
+            updatedTimestamp = createdTimestamp;
         }
 
         @Override
@@ -170,6 +172,7 @@ public class GraphMLConversionTest {
 
         public void setAlarms(List<Alarm> alarms) {
             this.alarms = alarms;
+            updatedTimestamp = System.currentTimeMillis();
         }
 
         @Override
@@ -178,18 +181,23 @@ public class GraphMLConversionTest {
         }
 
         @Override
-        public long getTimestamp() {
-            return timestamp;
+        public long getCreatedTimestamp() {
+            return createdTimestamp;
+        }
+
+        @Override
+        public long getUpdatedTimestamp() {
+            return updatedTimestamp;
         }
     }
 
     private static class MyEdge implements Edge {
         private final String id;
-        private final long timestamp;
+        private final long createdTimestamp;
 
         MyEdge(String id) {
             this.id = Objects.requireNonNull(id);
-            timestamp = System.currentTimeMillis();
+            createdTimestamp = System.currentTimeMillis();
         }
 
         @Override
@@ -208,8 +216,8 @@ public class GraphMLConversionTest {
         }
 
         @Override
-        public long getTimestamp() {
-            return timestamp;
+        public long getCreatedTimestamp() {
+            return createdTimestamp;
         }
     }
 

--- a/features/graph/common/src/test/java/org/opennms/oce/features/graph/common/GraphMLConversionTest.java
+++ b/features/graph/common/src/test/java/org/opennms/oce/features/graph/common/GraphMLConversionTest.java
@@ -151,9 +151,11 @@ public class GraphMLConversionTest {
     private static class MyVertex implements Vertex {
         private final String id;
         private List<Alarm> alarms = new ArrayList<>();
+        private final long timestamp;
 
         MyVertex(String id) {
             this.id = Objects.requireNonNull(id);
+            timestamp = System.currentTimeMillis();
         }
 
         @Override
@@ -174,13 +176,20 @@ public class GraphMLConversionTest {
         public Optional<InventoryObject> getInventoryObject() {
             return Optional.empty();
         }
+
+        @Override
+        public long getTimestamp() {
+            return timestamp;
+        }
     }
 
     private static class MyEdge implements Edge {
         private final String id;
+        private final long timestamp;
 
         MyEdge(String id) {
             this.id = Objects.requireNonNull(id);
+            timestamp = System.currentTimeMillis();
         }
 
         @Override
@@ -196,6 +205,11 @@ public class GraphMLConversionTest {
         @Override
         public Optional<InventoryObjectRelativeRef> getInventoryObjectRelativeRef() {
             return Optional.empty();
+        }
+
+        @Override
+        public long getTimestamp() {
+            return timestamp;
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/OCE-5

Timestamps are now written out to the GraphML like so:

```
...
<node id="vertex-0">
         <data key="timestamp">1539704127656</data>
</node>
...
```

