### PR TITLE
OCE-18: Race condition on engine init

### DIFF
--- a/datasource/api/src/main/java/org/opennms/oce/datasource/api/AlarmDatasource.java
+++ b/datasource/api/src/main/java/org/opennms/oce/datasource/api/AlarmDatasource.java
@@ -40,4 +40,6 @@ public interface AlarmDatasource {
 
     void unregisterHandler(AlarmHandler handler);
 
+    void waitUntilReady() throws InterruptedException;
+
 }

--- a/datasource/api/src/main/java/org/opennms/oce/datasource/api/IncidentDatasource.java
+++ b/datasource/api/src/main/java/org/opennms/oce/datasource/api/IncidentDatasource.java
@@ -40,4 +40,6 @@ public interface IncidentDatasource {
 
     void unregisterHandler(SituationHandler handler);
 
+    void waitUntilReady() throws InterruptedException;
+
 }

--- a/datasource/api/src/main/java/org/opennms/oce/datasource/api/InventoryDatasource.java
+++ b/datasource/api/src/main/java/org/opennms/oce/datasource/api/InventoryDatasource.java
@@ -39,5 +39,7 @@ public interface InventoryDatasource {
     void registerHandler(InventoryHandler handler);
 
     void unregisterHandler(InventoryHandler handler);
+    
+    void waitUntilReady() throws InterruptedException;
 
 }

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/StaticAlarmDatasource.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/StaticAlarmDatasource.java
@@ -61,4 +61,9 @@ public class StaticAlarmDatasource implements AlarmDatasource {
     public void unregisterHandler(AlarmHandler handler) {
         // pass
     }
+
+    @Override
+    public void waitUntilReady() {
+        // pass
+    }
 }

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/StaticIncidentDatasource.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/StaticIncidentDatasource.java
@@ -59,4 +59,9 @@ public class StaticIncidentDatasource implements IncidentDatasource {
     @Override
     public void unregisterHandler(SituationHandler handler) {
     }
+
+    @Override
+    public void waitUntilReady() {
+        // pass
+    }
 }

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/StaticInventoryDatasource.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/StaticInventoryDatasource.java
@@ -62,4 +62,9 @@ public class StaticInventoryDatasource implements InventoryDatasource {
     public void unregisterHandler(InventoryHandler handler) {
         // pass
     }
+
+    @Override
+    public void waitUntilReady() {
+        // pass
+    }
 }

--- a/datasource/opennms/src/main/java/org/opennms/oce/datasource/opennms/OpennmsDatasource.java
+++ b/datasource/opennms/src/main/java/org/opennms/oce/datasource/opennms/OpennmsDatasource.java
@@ -454,4 +454,11 @@ public class OpennmsDatasource implements IncidentDatasource, AlarmDatasource, I
     public void setInventoryTtlMs(long inventoryTtlMs) {
         this.inventoryTtlMs = inventoryTtlMs;
     }
+
+    @Override
+    public void waitUntilReady() throws InterruptedException {
+        waitUntilInventoryStoreIsQueryable();
+        waitUntilAlarmStoreIsQueryable();
+        waitUntilIncidentStoreIsQueryable();
+    }
 }

--- a/driver/main/src/main/java/org/opennms/oce/driver/main/Driver.java
+++ b/driver/main/src/main/java/org/opennms/oce/driver/main/Driver.java
@@ -102,6 +102,15 @@ public class Driver {
         // The get methods on the datasources may block, so we do this on a separate thread
         initThread = new Thread(() -> {
             try {
+                // Wait for all the data sources to be ready to minimize the time between when we register handlers and
+                // the engine inits
+                LOG.info("Waiting for inventory datasource...");
+                inventoryDatasource.waitUntilReady();
+                LOG.info("Waiting for alarm datasource...");
+                alarmDatasource.waitUntilReady();
+                LOG.info("Waiting for situation datasource...");
+                incidentDatasource.waitUntilReady();
+
                 LOG.info("Retrieving inventory...");
                 final List<InventoryObject> inventory = inventoryDatasource.getInventoryAndRegisterHandler(engine);
                 LOG.info("Retrieving alarms...");

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngine.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngine.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -126,6 +127,9 @@ public class ClusterEngine implements Engine, GraphProvider {
     private Set<Long> disconnectedVertices = new HashSet<>();
 
     private final GraphManager graphManager = new GraphManager();
+    
+    // Used to prevent processing callbacks before the init has completed
+    private final CountDownLatch initLock = new CountDownLatch(1);
 
     public ClusterEngine() {
         this(DEFAULT_EPSILON, DEFAULT_ALPHA, DEFAULT_BETA);
@@ -167,25 +171,29 @@ public class ClusterEngine implements Engine, GraphProvider {
 
     @Override
     public void init(List<Alarm> alarms, List<Incident> incidents, List<InventoryObject> inventory) {
-        LOG.debug("Initialized with {} alarms, {} incidents and {} inventory objects.", alarms.size(), incidents.size(), inventory.size());
-        LOG.debug("Alarms on init: {}", alarms);
-        LOG.debug("Incidents on init: {}", incidents);
-        LOG.debug("Inventory objects on init: {}", inventory);
-        graphManager.addInventory(inventory);
-        graphManager.addOrUpdateAlarms(alarms);
+        try {
+            LOG.debug("Initialized with {} alarms, {} incidents and {} inventory objects.", alarms.size(), incidents.size(), inventory.size());
+            LOG.debug("Alarms on init: {}", alarms);
+            LOG.debug("Incidents on init: {}", incidents);
+            LOG.debug("Inventory objects on init: {}", inventory);
+            graphManager.addInventory(inventory);
+            graphManager.addOrUpdateAlarms(alarms);
 
-        // Index the given incidents and the alarms they contain, so that we can cluster alarms in existing
-        // incidents when applicable
-        for (Incident incident : incidents) {
-            final IncidentBean incidentBean = new IncidentBean(incident);
-            incidentsById.put(incidentBean.getId(), incidentBean);
-            for (Alarm alarmInIncident : incidentBean.getAlarms()) {
-                alarmIdToIncidentMap.put(alarmInIncident.getId(), incidentBean);
+            // Index the given incidents and the alarms they contain, so that we can cluster alarms in existing
+            // incidents when applicable
+            for (Incident incident : incidents) {
+                final IncidentBean incidentBean = new IncidentBean(incident);
+                incidentsById.put(incidentBean.getId(), incidentBean);
+                for (Alarm alarmInIncident : incidentBean.getAlarms()) {
+                    alarmIdToIncidentMap.put(alarmInIncident.getId(), incidentBean);
+                }
             }
-        }
 
-        if (alarms.size()>0) {
-            alarmsChangedSinceLastTick = true;
+            if (alarms.size() > 0) {
+                alarmsChangedSinceLastTick = true;
+            }
+        } finally {
+            initLock.countDown();
         }
     }
 
@@ -381,24 +389,38 @@ public class ClusterEngine implements Engine, GraphProvider {
 
     @Override
     public void onAlarmCreatedOrUpdated(Alarm alarm) {
-        graphManager.addOrUpdateAlarm(alarm);
-        alarmsChangedSinceLastTick = true;
+        try {
+            initLock.await();
+            graphManager.addOrUpdateAlarm(alarm);
+            alarmsChangedSinceLastTick = true;
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while handling callback");
+        }
     }
 
     @Override
     public void onAlarmCleared(Alarm alarm) {
-        graphManager.addOrUpdateAlarm(alarm);
-        alarmsChangedSinceLastTick = true;
+        onAlarmCreatedOrUpdated(alarm);
     }
 
     @Override
     public void onInventoryAdded(Collection<InventoryObject> inventory) {
-        graphManager.addInventory(inventory);
+        try {
+            initLock.await();
+            graphManager.addInventory(inventory);
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while handling callback");
+        }
     }
 
     @Override
     public void onInventoryRemoved(Collection<InventoryObject> inventory) {
-        graphManager.removeInventory(inventory);
+        try {
+            initLock.await();
+            graphManager.removeInventory(inventory);
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while handling callback");
+        }
     }
 
 

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngine.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngine.java
@@ -393,14 +393,22 @@ public class ClusterEngine implements Engine, GraphProvider {
             initLock.await();
             graphManager.addOrUpdateAlarm(alarm);
             alarmsChangedSinceLastTick = true;
-        } catch (InterruptedException e) {
-            LOG.warn("Interrupted while handling callback");
+        } catch (InterruptedException ignore) {
+            LOG.debug("Interrupted while handling callback, skipping processing onAlarmCreatedOrUpdated");
+            Thread.currentThread().interrupt();
         }
     }
 
     @Override
     public void onAlarmCleared(Alarm alarm) {
-        onAlarmCreatedOrUpdated(alarm);
+        try {
+            initLock.await();
+            graphManager.addOrUpdateAlarm(alarm);
+            alarmsChangedSinceLastTick = true;
+        } catch (InterruptedException ignore) {
+            LOG.debug("Interrupted while handling callback, skipping processing onAlarmCleared");
+            Thread.currentThread().interrupt();
+        }
     }
 
     @Override
@@ -408,8 +416,9 @@ public class ClusterEngine implements Engine, GraphProvider {
         try {
             initLock.await();
             graphManager.addInventory(inventory);
-        } catch (InterruptedException e) {
-            LOG.warn("Interrupted while handling callback");
+        } catch (InterruptedException ignore) {
+            LOG.debug("Interrupted while handling callback, skipping processing onInventoryAdded");
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -418,8 +427,9 @@ public class ClusterEngine implements Engine, GraphProvider {
         try {
             initLock.await();
             graphManager.removeInventory(inventory);
-        } catch (InterruptedException e) {
-            LOG.warn("Interrupted while handling callback");
+        } catch (InterruptedException ignore) {
+            LOG.debug("Interrupted while handling callback, skipping processing onInventoryRemoved");
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEnginePerfTest.java
+++ b/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEnginePerfTest.java
@@ -45,6 +45,7 @@ public class ClusterEnginePerfTest {
     @Test
     public void canRunDBScanOnLargeGraphs() {
         final ClusterEngine clusterEngine = new ClusterEngine();
+        clusterEngine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         final int K = 500;
         for (int k = 0; k < K; k++) {
             final InventoryObjectBean node = new InventoryObjectBean();

--- a/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEngineTest.java
+++ b/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEngineTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -71,7 +72,8 @@ public class ClusterEngineTest implements IncidentHandler {
 
     @Before
     public void setUp() {
-        engine.registerIncidentHandler(this);
+        engine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        engine.registerIncidentHandler(this);        
     }
 
     @Test


### PR DESCRIPTION
This is a trivial fix for the race condition. It comes with the caveat that the callbacks can now block which means they will block any other handlers in the handler registry (since it is single threaded) until the init is finished. I think that probably isn't much of a problem but let me know if you see an issue with that.