### PR TITLE
OCE-23: Update JanusGraph implementation to support Cassandra as a persistent backend

### DIFF
--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngine.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngine.java
@@ -30,6 +30,7 @@ package org.opennms.oce.engine.cluster;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -120,25 +121,38 @@ public class ClusterEngine implements Engine, GraphProvider {
 
     private final double epsilon;
 
-    private long problemTimeoutMs = TimeUnit.HOURS.toMillis(2);
-    private long clearTimeoutMs = TimeUnit.MINUTES.toMillis(5);
+    @VisibleForTesting
+    public final long problemTimeoutMs = TimeUnit.HOURS.toMillis(2);
+
+    @VisibleForTesting
+    public final long clearTimeoutMs = TimeUnit.MINUTES.toMillis(5);
 
     private boolean alarmsChangedSinceLastTick = false;
     private DijkstraShortestPath<CEVertex, CEEdge> shortestPath;
     private Set<Long> disconnectedVertices = new HashSet<>();
 
-    private final GraphManager graphManager = new GraphManager();
+    private final ManagedCEGraph ceGraph = new ManagedCEGraph();
+    private final GraphManager graphManager;
     
     // Used to prevent processing callbacks before the init has completed
     private final CountDownLatch initLock = new CountDownLatch(1);
 
     public ClusterEngine() {
-        this(DEFAULT_EPSILON, DEFAULT_ALPHA, DEFAULT_BETA);
+        this(DEFAULT_EPSILON, DEFAULT_ALPHA, DEFAULT_BETA, null);
     }
 
-    public ClusterEngine(double epsilon, double alpha, double beta) {
+    public ClusterEngine(double epsilon, double alpha, double beta, GraphManager graphManager) {
         this.epsilon = epsilon;
         distanceMeasure = new AlarmInSpaceTimeDistanceMeasure(this, alpha, beta);
+
+        if (graphManager != null) {
+            this.graphManager = graphManager;
+            this.graphManager.addGraph(ceGraph);
+        } else {
+            // If we didn't get passed a GraphManager then we are likely in a test context so we can instantiate one
+            // directly
+            this.graphManager = GraphManager.newGraphManagerWithGraphs(Collections.singleton(ceGraph));
+        }
     }
 
     @Override
@@ -200,7 +214,7 @@ public class ClusterEngine implements Engine, GraphProvider {
 
     @Override
     public void destroy() {
-        // no-op
+        graphManager.close();
     }
 
     @Override
@@ -232,21 +246,16 @@ public class ClusterEngine implements Engine, GraphProvider {
 
         // Perform the clustering with the graph locked
         final Set<SituationBean> situations = new HashSet<>();
-        graphManager.withGraph(g -> {
-            if (graphManager.getDidGraphChangeAndReset()) {
+        ceGraph.withGraph(g -> {
+            if (ceGraph.getDidGraphChangeAndReset()) {
                 // If the graph has changed, then reset the cache
                 LOG.debug("{}: Graph has changed. Resetting hop cache.", timestampInMillis);
                 spatialDistances.invalidateAll();
                 shortestPath = null;
-                disconnectedVertices = graphManager.getDisconnectedVertices();
+                disconnectedVertices = ceGraph.getDisconnectedVertices();
             }
 
-            // GC alarms from vertices
-            int numGarbageCollectedAlarms = 0;
-            for (CEVertex v : g.getVertices()) {
-                numGarbageCollectedAlarms += v.garbageCollectAlarms(timestampInMillis, problemTimeoutMs, clearTimeoutMs);
-            }
-            LOG.debug("{}: Garbage collected {} alarms.", timestampInMillis, numGarbageCollectedAlarms);
+            graphManager.garbageCollectAlarms(timestampInMillis, problemTimeoutMs, clearTimeoutMs);
 
             // Ensure the points are sorted in order to make sure that the output of the clusterer is deterministic
             // OPTIMIZATION: Can we avoid doing this every tick?
@@ -257,7 +266,7 @@ public class ClusterEngine implements Engine, GraphProvider {
                     .flatMap(Collection::stream)
                     .sorted(Comparator.comparing(AlarmInSpaceTime::getAlarmTime).thenComparing(AlarmInSpaceTime::getAlarmId))
                     .collect(Collectors.toList());
-            if (alarms.size() < 1) {
+            if (alarms.isEmpty()) {
                 LOG.debug("{}: The graph contains no alarms. No clustering will be performed.", timestampInMillis);
                 return;
             }
@@ -456,7 +465,7 @@ public class ClusterEngine implements Engine, GraphProvider {
     @Override
     public <V> V withReadOnlyGraph(Function<OceGraph, V> consumer) {
         final List<Situation> situations = new ArrayList<>(situationsById.values());
-        return graphManager.withReadOnlyGraph(g -> {
+        return ceGraph.withReadOnlyGraph(g -> {
             final OceGraph oceGraph = new OceGraph() {
                 @Override
                 public Graph<? extends Vertex, ? extends Edge> getGraph() {
@@ -480,7 +489,7 @@ public class ClusterEngine implements Engine, GraphProvider {
                             return null;
                         }
                     }
-                    return graphManager.getVertexWithId(idAsLong);
+                    return ceGraph.getVertexWithId(idAsLong);
                 }
             };
             return consumer.apply(oceGraph);
@@ -515,8 +524,8 @@ public class ClusterEngine implements Engine, GraphProvider {
     }
 
     private Optional<Long> getOptionalVertexIdForAlarm(Alarm alarm) {
-        return graphManager.withGraph(g -> {
-            for (CEVertex v : graphManager.getGraph().getVertices()) {
+        return ceGraph.withGraph(g -> {
+            for (CEVertex v : ceGraph.getGraph().getVertices()) {
                 final Optional<Alarm> match = v.getAlarms().stream()
                         .filter(a -> a.equals(alarm))
                         .findFirst();
@@ -570,17 +579,17 @@ public class ClusterEngine implements Engine, GraphProvider {
                             if (disconnectedVertices.contains(key.vertexIdA) || disconnectedVertices.contains(key.vertexIdB)) {
                                 return 0;
                             }
-                            final CEVertex vertexA = graphManager.getVertexWithId(key.vertexIdA);
+                            final CEVertex vertexA = ceGraph.getVertexWithId(key.vertexIdA);
                             if (vertexA == null) {
                                 throw new IllegalStateException("Could not find vertex with id: " + key.vertexIdA);
                             }
-                            final CEVertex vertexB = graphManager.getVertexWithId(key.vertexIdB);
+                            final CEVertex vertexB = ceGraph.getVertexWithId(key.vertexIdB);
                             if (vertexB == null) {
                                 throw new IllegalStateException("Could not find vertex with id: " + key.vertexIdB);
                             }
 
                             if (shortestPath == null) {
-                                shortestPath = new DijkstraShortestPath<>(graphManager.getGraph(), CEEdge::getWeight,true);
+                                shortestPath = new DijkstraShortestPath<>(ceGraph.getGraph(), CEEdge::getWeight,true);
                             }
 
                             Number distance = shortestPath.getDistance(vertexA, vertexB);
@@ -625,7 +634,12 @@ public class ClusterEngine implements Engine, GraphProvider {
 
     @VisibleForTesting
     Graph<CEVertex, CEEdge> getGraph() {
-        return graphManager.getGraph();
+        return ceGraph.getGraph();
+    }
+    
+    @VisibleForTesting
+    public GraphManager getGraphManager() {
+        return graphManager;
     }
 
     @VisibleForTesting

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngineFactory.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ClusterEngineFactory.java
@@ -35,6 +35,7 @@ public class ClusterEngineFactory implements EngineFactory {
     private double epsilon = ClusterEngine.DEFAULT_EPSILON;
     private double alpha = ClusterEngine.DEFAULT_ALPHA;
     private double beta = ClusterEngine.DEFAULT_BETA;
+    private GraphManager graphManager;
 
     @Override
     public String getName() {
@@ -48,7 +49,7 @@ public class ClusterEngineFactory implements EngineFactory {
 
     @Override
     public ClusterEngine createEngine() {
-        return new ClusterEngine(epsilon, alpha, beta);
+        return new ClusterEngine(epsilon, alpha, beta, graphManager);
     }
 
     public double getEpsilon() {
@@ -73,5 +74,13 @@ public class ClusterEngineFactory implements EngineFactory {
 
     public void setBeta(double beta) {
         this.beta = beta;
+    }
+
+    public GraphManager getGraphManager() {
+        return graphManager;
+    }
+
+    public void setGraphManager(GraphManager graphManager) {
+        this.graphManager = graphManager;
     }
 }

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/GraphManager.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/GraphManager.java
@@ -29,252 +29,171 @@
 package org.opennms.oce.engine.cluster;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.opennms.oce.datasource.api.Alarm;
 import org.opennms.oce.datasource.api.InventoryObject;
-import org.opennms.oce.datasource.api.InventoryObjectPeerRef;
-import org.opennms.oce.datasource.api.InventoryObjectRelativeRef;
-import org.opennms.oce.datasource.api.ResourceKey;
-import org.opennms.oce.features.graph.api.Edge;
-import org.opennms.oce.features.graph.api.Vertex;
+import org.opennms.oce.features.graph.api.ManagedGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.uci.ics.jung.graph.Graph;
-import edu.uci.ics.jung.graph.SparseMultigraph;
-
-public class GraphManager {
-
+/**
+ * This class serves as the primary point of contact for the {@link ClusterEngine} for processing changes that could
+ * affect a graph. This class receives the calls specified in {@link ManagedGraph} and proxies them to all of the graph
+ * implementations resulting in the graph(s) being kept up to date and consistent.
+ * <p>
+ * All {@link ManagedGraph} calls handled by this class are synchronized and the processing happens in a single thread.
+ * Therefore these methods will block until all graph implementations have handled the call.
+ */
+public class GraphManager implements ManagedGraph {
     private static final Logger LOG = LoggerFactory.getLogger(GraphManager.class);
 
-    private final AtomicLong vertexIdGenerator = new AtomicLong();
-    private final AtomicLong edgeIdGenerator = new AtomicLong();
+    /**
+     * The graph instances managed by this graph manager. Updated via runtime binding.
+     */
+    private final Set<ManagedGraph> graphs = new HashSet<>();
 
-    private final Map<Long, CEVertex> idtoVertexMap = new HashMap<>();
-    private final Map<ResourceKey, CEVertex> resourceKeyVertexMap = new HashMap<>();
+    private GraphManager(Set<ManagedGraph> defaultGraphs) {
+        defaultGraphs.forEach(this::addGraph);
+    }
 
-    private final Graph<CEVertex, CEEdge> g = new SparseMultigraph<>();
+    public synchronized void onBind(ManagedGraph managedGraph, Map properties) {
+        // Ignore binds for ManagedCEGraph since that implementation is manually managed
+        if (managedGraph instanceof ManagedCEGraph) {
+            LOG.warn("Attempted to bind an instance of ManagedCEGraph");
 
-    private final AtomicBoolean didGraphChange = new AtomicBoolean();
+            return;
+        }
 
-    private final Set<Long> disconnectedVertices = new HashSet<>();
+        // This GraphManager should never be managing another GraphManager
+        if (managedGraph instanceof GraphManager) {
+            LOG.warn("Attempted to bind an instance of GraphManager");
 
-    private Set<InventoryObject> deferredIos = new HashSet<>();
+            return;
+        }
 
+        LOG.debug("bind called with {}: {}", managedGraph, properties);
+
+        if (managedGraph != null) {
+            addGraph(managedGraph);
+        }
+    }
+
+    public synchronized void onUnbind(ManagedGraph managedGraph, Map properties) {
+        // Ignore unbinds for ManagedCEGraph since that implementation is manually managed
+        if (managedGraph instanceof ManagedCEGraph) {
+            return;
+        }
+
+        // This GraphManager should never be managing another GraphManager
+        if (managedGraph instanceof GraphManager) {
+            LOG.warn("Attempted to unbind an instance of GraphManager");
+
+            return;
+        }
+
+        LOG.debug("Unbind called with {}: {}", managedGraph, properties);
+
+        if (managedGraph != null) {
+            removeGraph(managedGraph);
+        }
+    }
+
+    public static GraphManager newGraphManager() {
+        return new GraphManager(Collections.emptySet());
+    }
+    
+    public static GraphManager newGraphManagerWithGraphs(Set<ManagedGraph> defaultGraphs) {
+        return new GraphManager(defaultGraphs);
+    }
+
+    @Override
     public synchronized void addInventory(Collection<InventoryObject> inventory) {
-        addInventory(inventory, false);
-    }
+        graphs.forEach(graph -> {
+            LOG.debug("Proxying addInventory call to graph {}", graph);
 
-    private synchronized void addInventory(Collection<InventoryObject> inventory, boolean isDeferred) {
-        // Start off by adding vertices to the graph for any new object
-        for (InventoryObject io : inventory) {
-            final ResourceKey resourceKey = getResourceKeyFor(io);
-            resourceKeyVertexMap.computeIfAbsent(resourceKey, (key) -> {
-                LOG.trace("Adding vertex with resource key: {} for inventory object: {}", resourceKey, io);
-                final CEVertex vertex = createVertexFor(io);
-                g.addVertex(vertex);
-                didGraphChange.set(true);
-                idtoVertexMap.put(vertex.getNumericId(), vertex);
-                return vertex;
-            });
-        }
-
-        // Now handle the relationships
-        boolean didMatchAllRelations = true;
-        for (InventoryObject io : inventory) {
-            final ResourceKey resourceKey = getResourceKeyFor(io);
-            final CEVertex vertex = resourceKeyVertexMap.get(resourceKey);
-
-            // Parent relationships
-            final ResourceKey parentResourceKey = getResourceKeyForParent(io);
-            if (parentResourceKey != null) {
-                final CEVertex parentVertex = resourceKeyVertexMap.get(parentResourceKey);
-                if (parentVertex == null) {
-                    LOG.info("No existing vertex found for parent with resource key '{}' on vertex with resource key '{}'. Deferring edge association.", parentResourceKey, resourceKey);
-                    didMatchAllRelations = false;
-                    continue;
-                }
-                if (!g.isNeighbor(parentVertex, vertex)) {
-                    LOG.trace("Adding edge between child: {} and parent: {}", vertex, parentVertex);
-                    final CEEdge edge = CEEdge.newParentEdge(edgeIdGenerator.getAndIncrement(), io.getWeightToParent());
-                    g.addEdge(edge, parentVertex, vertex);
-                    didGraphChange.set(true);
-                }
+            try {
+                graph.addInventory(inventory);
+            } catch (Exception e) {
+                LOG.warn("addInventory call to graph {} caused an exception", graph, e);
             }
-
-            // Peer relationships
-            for (InventoryObjectPeerRef peerRef : io.getPeers()) {
-                final ResourceKey peerResourceKey = getResourceKeyForPeer(peerRef);
-                final CEVertex peerVertex = resourceKeyVertexMap.get(peerResourceKey);
-                if (peerVertex == null) {
-                    LOG.info("No existing vertex found for peer with resource key '{}' on vertex with resource key '{}'. Deferring edge association.", peerResourceKey, resourceKey);
-                    didMatchAllRelations = false;
-                    continue;
-                }
-                if (!g.isNeighbor(peerVertex, vertex)) {
-                    LOG.debug("Adding edge between peers A: {} and Z: {}", peerVertex, vertex);
-                    final CEEdge edge = CEEdge.newPeerEdge(edgeIdGenerator.getAndIncrement(), peerRef);
-                    g.addEdge(edge, peerVertex, vertex);
-                    didGraphChange.set(true);
-                }
-            }
-
-            // Relative relationships
-            for (InventoryObjectRelativeRef relativeRef : io.getRelatives()) {
-                final ResourceKey relativeResourceKey = getResourceKeyForPeer(relativeRef);
-                final CEVertex relativeVertex = resourceKeyVertexMap.get(relativeResourceKey);
-                if (relativeVertex == null) {
-                    LOG.info("No existing vertex found for relative with resource key '{}' on vertex with resource key '{}'. Deferring edge association.", relativeResourceKey, resourceKey);
-                    didMatchAllRelations = false;
-                    continue;
-                }
-                if (!g.isNeighbor(relativeVertex, vertex)) {
-                    LOG.debug("Adding edge between relatives A: {} and Z: {}", relativeVertex, vertex);
-                    final CEEdge edge = CEEdge.newRelativeEdge(edgeIdGenerator.getAndIncrement(), relativeRef);
-                    g.addEdge(edge, relativeVertex, vertex);
-                    didGraphChange.set(true);
-                }
-            }
-
-            if (!didMatchAllRelations && !isDeferred) {
-                deferredIos.add(io);
-            } else if (isDeferred && didMatchAllRelations) {
-                deferredIos.remove(io);
-            }
-        }
-
-        if (!isDeferred) {
-            handleDeferredIos();
-        }
-
-        disconnectedVertices.clear();
-        disconnectedVertices.addAll(g.getVertices().stream()
-                .filter(v -> g.getNeighborCount(v) == 0)
-                .map(CEVertex::getNumericId)
-                .collect(Collectors.toList()));
-    }
-
-    private void handleDeferredIos() {
-        if (deferredIos.size() < 1) {
-            return;
-        }
-        addInventory(new LinkedList<>(deferredIos), true);
-    }
-
-    public synchronized void removeInventory(Collection<InventoryObject> inventory) {
-        for (InventoryObject io : inventory) {
-            final ResourceKey resourceKey = getResourceKeyFor(io);
-            final CEVertex vertex = resourceKeyVertexMap.remove(resourceKey);
-            if (vertex != null) {
-                g.removeVertex(vertex);
-                didGraphChange.set(true);
-            }
-            deferredIos.remove(io);
-        }
-    }
-
-    public synchronized void addOrUpdateAlarms(List<Alarm> alarms) {
-        for (Alarm alarm : alarms) {
-            addOrUpdateAlarm(alarm);
-        }
-    }
-
-    public synchronized void addOrUpdateAlarm(Alarm alarm) {
-        if (alarm.getInventoryObjectType() == null || alarm.getInventoryObjectId() == null) {
-            LOG.info("Alarm with id: {} is not associated with any resource. It will not be added to the graph.", alarm.getId());
-            return;
-        }
-        final ResourceKey resourceKey = getResourceKeyFor(alarm);
-        final CEVertex vertex = resourceKeyVertexMap.computeIfAbsent(resourceKey, (key) -> {
-            LOG.info("No existing vertex was found with resource key: {} for alarm with id: {}. Creating a new vertex.", resourceKey, alarm.getId());
-            final CEVertex v = new CEVertex(vertexIdGenerator.getAndIncrement(), resourceKey);
-            g.addVertex(v);
-            didGraphChange.set(true);
-            idtoVertexMap.put(v.getNumericId(), v);
-            handleDeferredIos();
-            return v;
         });
-        vertex.addOrUpdateAlarm(alarm);
     }
 
-    public <V> V withReadOnlyGraph(Function<Graph<? extends Vertex, ? extends Edge>, V> consumer) {
-        return consumer.apply(g);
+    @Override
+    public synchronized void removeInventory(Collection<InventoryObject> inventory) {
+        graphs.forEach(graph -> {
+            LOG.debug("Proxying removeInventory call to graph {}", graph);
+
+            try {
+                graph.removeInventory(inventory);
+            } catch (Exception e) {
+                LOG.warn("removeInventory call to graph {} caused an exception", graph, e);
+            }
+        });
     }
 
-    public void withReadOnlyGraph(Consumer<Graph<? extends Vertex, ? extends Edge>> consumer) {
-        consumer.accept(g);
+    @Override
+    public synchronized void addOrUpdateAlarm(Alarm alarm) {
+        graphs.forEach(graph -> {
+            LOG.debug("Proxying addOrUpdateAlarm call to graph {}", graph);
+
+            try {
+                graph.addOrUpdateAlarm(alarm);
+            } catch (Exception e) {
+                LOG.warn("addOrUpdateAlarm call to graph {} caused an exception", graph, e);
+            }
+        });
     }
 
-    public synchronized <V> V withGraph(Function<Graph<CEVertex, CEEdge>, V> consumer) {
-        return consumer.apply(g);
+    @Override
+    public synchronized void addOrUpdateAlarms(List<Alarm> alarms) {
+        graphs.forEach(graph -> {
+            LOG.debug("Proxying addOrUpdateAlarms call to graph {}", graph);
+
+            try {
+                graph.addOrUpdateAlarms(alarms);
+            } catch (Exception e) {
+                LOG.warn("addOrUpdateAlarms call to graph {} caused an exception", graph, e);
+            }
+        });
     }
 
-    public synchronized void withGraph(Consumer<Graph<CEVertex, CEEdge>> consumer) {
-        consumer.accept(g);
+    @Override
+    public synchronized void garbageCollectAlarms(long currentTimeMs, long problemTimeoutMs, long clearTimeoutMs) {
+        graphs.forEach(graph -> {
+            LOG.debug("Proxying garbageCollectAlarms call to graph {}", graph);
+
+            try {
+                graph.garbageCollectAlarms(currentTimeMs, problemTimeoutMs, clearTimeoutMs);
+            } catch (Exception e) {
+                LOG.warn("garbageCollectAlarms call to graph {} caused an exception", graph, e);
+            }
+        });
     }
 
-    public synchronized void withVertex(String type, String id, BiConsumer<Graph<CEVertex, CEEdge>, CEVertex> consumer) {
-        consumer.accept(g, resourceKeyVertexMap.get(ResourceKey.key(type, id)));
+    @Override
+    public void close() {
+        graphs.forEach(graph -> {
+            LOG.debug("Proxying close call to graph {}", graph);
+
+            try {
+                graph.close();
+            } catch (Exception e) {
+                LOG.warn("close call to graph {} caused an exception", graph, e);
+            }
+        });
     }
 
-    protected Graph<CEVertex, CEEdge> getGraph() {
-        return g;
+    synchronized void addGraph(ManagedGraph managedGraph) {
+        graphs.add(managedGraph);
     }
 
-    protected CEVertex getVertexWithId(Long id) {
-        return idtoVertexMap.get(id);
+    synchronized void removeGraph(ManagedGraph managedGraph) {
+        graphs.remove(managedGraph);
     }
-
-    private CEVertex createVertexFor(InventoryObject io) {
-        final ResourceKey resourceKey = getResourceKeyFor(io);
-        return new CEVertex(vertexIdGenerator.getAndIncrement(), resourceKey, io);
-    }
-
-    private static ResourceKey getResourceKeyFor(InventoryObject io) {
-        return ResourceKey.key(io.getType(), io.getId());
-    }
-
-    private static ResourceKey getResourceKeyFor(Alarm alarm) {
-        return ResourceKey.key(alarm.getInventoryObjectType(), alarm.getInventoryObjectId());
-    }
-
-    private static ResourceKey getResourceKeyForParent(InventoryObject child) {
-        if (child.getParentType() != null && child.getParentId() != null) {
-            return ResourceKey.key(child.getParentType(), child.getParentId());
-        }
-        return null;
-    }
-
-    private static ResourceKey getResourceKeyForPeer(InventoryObjectPeerRef peerRef) {
-        return ResourceKey.key(peerRef.getType(), peerRef.getId());
-    }
-
-    private static ResourceKey getResourceKeyForPeer(InventoryObjectRelativeRef relativeRef) {
-        return ResourceKey.key(relativeRef.getType(), relativeRef.getId());
-    }
-
-    public boolean getDidGraphChangeAndReset() {
-        return didGraphChange.getAndSet(false);
-    }
-
-    public Set<Long> getDisconnectedVertices() {
-        return disconnectedVertices;
-    }
-
-    public int getNumDeferredObjects() {
-        return deferredIos.size();
-    }
-
 }

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/GraphManager.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/GraphManager.java
@@ -106,7 +106,7 @@ public class GraphManager implements ManagedGraph {
     public static GraphManager newGraphManager() {
         return new GraphManager(Collections.emptySet());
     }
-    
+
     public static GraphManager newGraphManagerWithGraphs(Set<ManagedGraph> defaultGraphs) {
         return new GraphManager(defaultGraphs);
     }
@@ -187,6 +187,9 @@ public class GraphManager implements ManagedGraph {
                 LOG.warn("close call to graph {} caused an exception", graph, e);
             }
         });
+
+        // Remove all the graphs from management
+        graphs.clear();
     }
 
     synchronized void addGraph(ManagedGraph managedGraph) {
@@ -194,6 +197,7 @@ public class GraphManager implements ManagedGraph {
     }
 
     synchronized void removeGraph(ManagedGraph managedGraph) {
+        managedGraph.close();
         graphs.remove(managedGraph);
     }
 }

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ManagedCEGraph.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/ManagedCEGraph.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.engine.cluster;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.opennms.oce.datasource.api.Alarm;
+import org.opennms.oce.datasource.api.InventoryObject;
+import org.opennms.oce.datasource.api.InventoryObjectPeerRef;
+import org.opennms.oce.datasource.api.InventoryObjectRelativeRef;
+import org.opennms.oce.datasource.api.ResourceKey;
+import org.opennms.oce.features.graph.api.AbstractManagedGraph;
+import org.opennms.oce.features.graph.api.Edge;
+import org.opennms.oce.features.graph.api.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.uci.ics.jung.graph.Graph;
+import edu.uci.ics.jung.graph.SparseMultigraph;
+
+public class ManagedCEGraph extends AbstractManagedGraph {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManagedCEGraph.class);
+
+    private final Map<Long, CEVertex> idtoVertexMap = new HashMap<>();
+    private final Map<ResourceKey, CEVertex> resourceKeyVertexMap = new HashMap<>();
+
+    private final Graph<CEVertex, CEEdge> g = new SparseMultigraph<>();
+
+    private Set<InventoryObject> deferredIos = new HashSet<>();
+
+    private final AtomicBoolean didGraphChange = new AtomicBoolean();
+    private final Set<Long> disconnectedVertices = new HashSet<>();
+
+    @Override
+    public synchronized void addInventory(Collection<InventoryObject> inventory) {
+        addInventory(inventory, false);
+    }
+
+    private synchronized void addInventory(Collection<InventoryObject> inventory, boolean isDeferred) {
+        // Start off by adding vertices to the graph for any new object
+        for (InventoryObject io : inventory) {
+            final ResourceKey resourceKey = getResourceKeyFor(io);
+            resourceKeyVertexMap.computeIfAbsent(resourceKey, (key) -> {
+                LOG.trace("Adding vertex with resource key: {} for inventory object: {}", resourceKey, io);
+                final CEVertex vertex = createVertexFor(io);
+                g.addVertex(vertex);
+                didGraphChange.set(true);
+                idtoVertexMap.put(vertex.getNumericId(), vertex);
+                return vertex;
+            });
+        }
+
+        // Now handle the relationships
+        boolean didMatchAllRelations = true;
+        for (InventoryObject io : inventory) {
+            final ResourceKey resourceKey = getResourceKeyFor(io);
+            final CEVertex vertex = resourceKeyVertexMap.get(resourceKey);
+
+            // Parent relationships
+            final ResourceKey parentResourceKey = getResourceKeyForParent(io);
+            if (parentResourceKey != null) {
+                final CEVertex parentVertex = resourceKeyVertexMap.get(parentResourceKey);
+                if (parentVertex == null) {
+                    LOG.info("No existing vertex found for parent with resource key '{}' on vertex with resource key '{}'. Deferring edge association.", parentResourceKey, resourceKey);
+                    didMatchAllRelations = false;
+                    continue;
+                }
+                if (!g.isNeighbor(parentVertex, vertex)) {
+                    LOG.trace("Adding edge between child: {} and parent: {}", vertex, parentVertex);
+                    final CEEdge edge = CEEdge.newParentEdge(edgeIdGenerator.getAndIncrement(), io.getWeightToParent());
+                    g.addEdge(edge, parentVertex, vertex);
+                    didGraphChange.set(true);
+                }
+            }
+
+            // Peer relationships
+            for (InventoryObjectPeerRef peerRef : io.getPeers()) {
+                final ResourceKey peerResourceKey = getResourceKeyForPeer(peerRef);
+                final CEVertex peerVertex = resourceKeyVertexMap.get(peerResourceKey);
+                if (peerVertex == null) {
+                    LOG.info("No existing vertex found for peer with resource key '{}' on vertex with resource key '{}'. Deferring edge association.", peerResourceKey, resourceKey);
+                    didMatchAllRelations = false;
+                    continue;
+                }
+                if (!g.isNeighbor(peerVertex, vertex)) {
+                    LOG.debug("Adding edge between peers A: {} and Z: {}", peerVertex, vertex);
+                    final CEEdge edge = CEEdge.newPeerEdge(edgeIdGenerator.getAndIncrement(), peerRef);
+                    g.addEdge(edge, peerVertex, vertex);
+                    didGraphChange.set(true);
+                }
+            }
+
+            // Relative relationships
+            for (InventoryObjectRelativeRef relativeRef : io.getRelatives()) {
+                final ResourceKey relativeResourceKey = getResourceKeyForPeer(relativeRef);
+                final CEVertex relativeVertex = resourceKeyVertexMap.get(relativeResourceKey);
+                if (relativeVertex == null) {
+                    LOG.info("No existing vertex found for relative with resource key '{}' on vertex with resource key '{}'. Deferring edge association.", relativeResourceKey, resourceKey);
+                    didMatchAllRelations = false;
+                    continue;
+                }
+                if (!g.isNeighbor(relativeVertex, vertex)) {
+                    LOG.debug("Adding edge between relatives A: {} and Z: {}", relativeVertex, vertex);
+                    final CEEdge edge = CEEdge.newRelativeEdge(edgeIdGenerator.getAndIncrement(), relativeRef);
+                    g.addEdge(edge, relativeVertex, vertex);
+                    didGraphChange.set(true);
+                }
+            }
+
+            if (!didMatchAllRelations && !isDeferred) {
+                deferredIos.add(io);
+            } else if (isDeferred && didMatchAllRelations) {
+                deferredIos.remove(io);
+            }
+        }
+
+        if (!isDeferred) {
+            handleDeferredIos();
+        }
+
+        disconnectedVertices.clear();
+        disconnectedVertices.addAll(g.getVertices().stream()
+                .filter(v -> g.getNeighborCount(v) == 0)
+                .map(CEVertex::getNumericId)
+                .collect(Collectors.toList()));
+    }
+
+    private void handleDeferredIos() {
+        if (deferredIos.size() < 1) {
+            return;
+        }
+        addInventory(new LinkedList<>(deferredIos), true);
+    }
+
+    @Override
+    public synchronized void removeInventory(Collection<InventoryObject> inventory) {
+        for (InventoryObject io : inventory) {
+            final ResourceKey resourceKey = getResourceKeyFor(io);
+            final CEVertex vertex = resourceKeyVertexMap.remove(resourceKey);
+            if (vertex != null) {
+                g.removeVertex(vertex);
+                didGraphChange.set(true);
+            }
+            deferredIos.remove(io);
+        }
+    }
+
+    @Override
+    public synchronized void addOrUpdateAlarm(Alarm alarm) {
+        if (alarm.getInventoryObjectType() == null || alarm.getInventoryObjectId() == null) {
+            LOG.info("Alarm with id: {} is not associated with any resource. It will not be added to the graph.", alarm.getId());
+            return;
+        }
+        final ResourceKey resourceKey = getResourceKeyFor(alarm);
+        final CEVertex vertex = resourceKeyVertexMap.computeIfAbsent(resourceKey, (key) -> {
+            LOG.info("No existing vertex was found with resource key: {} for alarm with id: {}. Creating a new vertex.", resourceKey, alarm.getId());
+            final CEVertex v = new CEVertex(vertexIdGenerator.getAndIncrement(), resourceKey);
+            g.addVertex(v);
+            didGraphChange.set(true);
+            idtoVertexMap.put(v.getNumericId(), v);
+            handleDeferredIos();
+            return v;
+        });
+        vertex.addOrUpdateAlarm(alarm);
+    }
+
+    @Override
+    public void garbageCollectAlarms(long currentTimeMs, long problemTimeoutMs, long clearTimeoutMs) {
+        // GC alarms from vertices
+        int numGarbageCollectedAlarms = 0;
+        for (CEVertex v : g.getVertices()) {
+            numGarbageCollectedAlarms += v.garbageCollectAlarms(currentTimeMs, problemTimeoutMs, clearTimeoutMs);
+        }
+        LOG.debug("{}: Garbage collected {} alarms.", currentTimeMs, numGarbageCollectedAlarms);
+    }
+
+    public <V> V withReadOnlyGraph(Function<Graph<? extends Vertex, ? extends Edge>, V> consumer) {
+        return consumer.apply(g);
+    }
+
+    public void withReadOnlyGraph(Consumer<Graph<? extends Vertex, ? extends Edge>> consumer) {
+        consumer.accept(g);
+    }
+
+    public synchronized <V> V withGraph(Function<Graph<CEVertex, CEEdge>, V> consumer) {
+        return consumer.apply(g);
+    }
+
+    public synchronized void withGraph(Consumer<Graph<CEVertex, CEEdge>> consumer) {
+        consumer.accept(g);
+    }
+
+    public synchronized void withVertex(String type, String id, BiConsumer<Graph<CEVertex, CEEdge>, CEVertex> consumer) {
+        consumer.accept(g, resourceKeyVertexMap.get(ResourceKey.key(type, id)));
+    }
+
+    protected Graph<CEVertex, CEEdge> getGraph() {
+        return g;
+    }
+
+    protected CEVertex getVertexWithId(Long id) {
+        return idtoVertexMap.get(id);
+    }
+
+    private CEVertex createVertexFor(InventoryObject io) {
+        final ResourceKey resourceKey = getResourceKeyFor(io);
+        return new CEVertex(vertexIdGenerator.getAndIncrement(), resourceKey, io);
+    }
+    
+    public boolean getDidGraphChangeAndReset() {
+        return didGraphChange.getAndSet(false);
+    }
+    
+    public Set<Long> getDisconnectedVertices() {
+        return disconnectedVertices;
+    }
+
+    public int getNumDeferredObjects() {
+        return deferredIos.size();
+    }
+
+    @Override
+    public int hashCode() {
+        return g.hashCode();
+    }
+}

--- a/engine/cluster/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/engine/cluster/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,9 +1,14 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+    <bean id="graphManager" class="org.opennms.oce.engine.cluster.GraphManager" factory-method="newGraphManager"/>
+    <reference-list interface="org.opennms.oce.features.graph.api.ManagedGraph" availability="optional">
+        <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="graphManager"/>
+    </reference-list>
 
     <!-- Create and expose the engine factory -->
     <service interface="org.opennms.oce.engine.api.EngineFactory">
-        <bean class="org.opennms.oce.engine.cluster.ClusterEngineFactory"/>
+        <bean class="org.opennms.oce.engine.cluster.ClusterEngineFactory">
+            <property name="graphManager" ref="graphManager"/>
+        </bean>
     </service>
-
 </blueprint>

--- a/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/AbstractManagedGraph.java
+++ b/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/AbstractManagedGraph.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.features.graph.api;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.opennms.oce.datasource.api.Alarm;
+import org.opennms.oce.datasource.api.InventoryObject;
+import org.opennms.oce.datasource.api.InventoryObjectPeerRef;
+import org.opennms.oce.datasource.api.InventoryObjectRelativeRef;
+import org.opennms.oce.datasource.api.ResourceKey;
+
+public abstract class AbstractManagedGraph implements ManagedGraph {
+    protected final AtomicLong vertexIdGenerator = new AtomicLong();
+    protected final AtomicLong edgeIdGenerator = new AtomicLong();
+
+    public abstract void addInventory(Collection<InventoryObject> inventory);
+
+    public abstract void removeInventory(Collection<InventoryObject> inventory);
+
+    public abstract void addOrUpdateAlarm(Alarm alarm);
+
+    public void addOrUpdateAlarms(List<Alarm> alarms) {
+        for (Alarm alarm : alarms) {
+            addOrUpdateAlarm(alarm);
+        }
+    }
+
+    protected static ResourceKey getResourceKeyFor(InventoryObject io) {
+        return ResourceKey.key(io.getType(), io.getId());
+    }
+
+    protected static ResourceKey getResourceKeyFor(Alarm alarm) {
+        return ResourceKey.key(alarm.getInventoryObjectType(), alarm.getInventoryObjectId());
+    }
+
+    protected static ResourceKey getResourceKeyForParent(InventoryObject child) {
+        if (child.getParentType() != null && child.getParentId() != null) {
+            return ResourceKey.key(child.getParentType(), child.getParentId());
+        }
+        return null;
+    }
+
+    protected static ResourceKey getResourceKeyForPeer(InventoryObjectPeerRef peerRef) {
+        return ResourceKey.key(peerRef.getType(), peerRef.getId());
+    }
+
+    protected static ResourceKey getResourceKeyForPeer(InventoryObjectRelativeRef relativeRef) {
+        return ResourceKey.key(relativeRef.getType(), relativeRef.getId());
+    }
+}

--- a/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/ManagedGraph.java
+++ b/features/graph/api/src/main/java/org/opennms/oce/features/graph/api/ManagedGraph.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.features.graph.api;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.opennms.oce.datasource.api.Alarm;
+import org.opennms.oce.datasource.api.InventoryObject;
+
+/**
+ * An interface that specifies the communication channel between the graph manager and the graph implementation. The
+ * calls specified in this interface are the primary way in which a graph is manipulated (vertices/edges added or
+ * deleted).
+ */
+public interface ManagedGraph {
+    /**
+     * Process inventory being added.
+     *
+     * @param inventory the collection of inventory objects to be added
+     */
+    void addInventory(Collection<InventoryObject> inventory);
+
+    /**
+     * Process inventory being removed.
+     *
+     * @param inventory the collection of inventory objects to be removed
+     */
+    void removeInventory(Collection<InventoryObject> inventory);
+
+    /**
+     * Process a single alarm being added or updated.
+     *
+     * @param alarm the alarm that is being added or updated
+     */
+    void addOrUpdateAlarm(Alarm alarm);
+
+    /**
+     * Process a list of alarms being added or updated.
+     *
+     * @param alarms the list of alarms being added or updated
+     */
+    void addOrUpdateAlarms(List<Alarm> alarms);
+
+    /**
+     * Garbage collect alarms from vertices.
+     * 
+     * @param currentTimeMs the current timestamp in milliseconds
+     * @param problemTimeoutMs the timeout for an alarm in milliseconds
+     * @param clearTimeoutMs the timeout for an alarm clear in milliseconds
+     */
+    void garbageCollectAlarms(long currentTimeMs, long problemTimeoutMs, long clearTimeoutMs);
+
+    /**
+     * Instruct the graph to close.
+     */
+    default void close() {
+        // no-op
+    }
+}

--- a/features/graph/janusgraph/pom.xml
+++ b/features/graph/janusgraph/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.opennms.oce.features</groupId>
+        <artifactId>graph</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opennms.oce.features.graph</groupId>
+    <artifactId>org.opennms.oce.features.graph.janusgraph</artifactId>
+    <name>OCE :: Features :: Graph :: JanusGraph</name>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.opennms.oce.datasource</groupId>
+            <artifactId>org.opennms.oce.datasource.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-core</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.oce.features.graph</groupId>
+            <artifactId>org.opennms.oce.features.graph.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.oce.engine</groupId>
+            <artifactId>org.opennms.oce.engine.cluster</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.oce.driver</groupId>
+            <artifactId>org.opennms.oce.driver.test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.1.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/features/graph/janusgraph/pom.xml
+++ b/features/graph/janusgraph/pom.xml
@@ -29,7 +29,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.opennms.oce.datasource</groupId>
@@ -38,6 +38,16 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-core</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-cql</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-es</artifactId>
             <version>0.3.1</version>
         </dependency>
         <dependency>
@@ -68,6 +78,24 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>2.1.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>pl.allegro.tech</groupId>
+            <artifactId>embedded-elasticsearch</artifactId>
+            <version>2.7.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/features/graph/janusgraph/src/main/java/org/opennms/oce/features/graph/janusgraph/AlarmBeanSerializer.java
+++ b/features/graph/janusgraph/src/main/java/org/opennms/oce/features/graph/janusgraph/AlarmBeanSerializer.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.features.graph.janusgraph;
+
+import java.util.Objects;
+
+import org.janusgraph.core.attribute.AttributeSerializer;
+import org.janusgraph.diskstorage.ScanBuffer;
+import org.janusgraph.diskstorage.WriteBuffer;
+import org.janusgraph.graphdb.database.serialize.attribute.IntegerSerializer;
+import org.janusgraph.graphdb.database.serialize.attribute.LongSerializer;
+import org.janusgraph.graphdb.database.serialize.attribute.StringSerializer;
+import org.opennms.oce.datasource.api.Severity;
+import org.opennms.oce.datasource.common.AlarmBean;
+
+/**
+ * This class serializes {@link AlarmBean} objects for persistence in JanusGraph.
+ */
+public class AlarmBeanSerializer implements AttributeSerializer<AlarmBean> {
+    private StringSerializer stringSerializer = new StringSerializer();
+    private LongSerializer longSerializer = new LongSerializer();
+    private IntegerSerializer integerSerializer = new IntegerSerializer();
+
+    @Override
+    public AlarmBean read(ScanBuffer buffer) {
+        String id = stringSerializer.read(buffer);
+        long time = longSerializer.read(buffer);
+        Severity severity = Severity.fromValue(integerSerializer.read(buffer));
+        String inventoryObjectId = stringSerializer.read(buffer);
+        String inventoryObjectType = stringSerializer.read(buffer);
+        String summary = stringSerializer.read(buffer);
+        String description = stringSerializer.read(buffer);
+
+        AlarmBean alarmBean = new AlarmBean(id, time);
+        alarmBean.setSeverity(severity);
+        alarmBean.setInventoryObjectId(inventoryObjectId);
+        alarmBean.setInventoryObjectType(inventoryObjectType);
+        alarmBean.setSummary(summary);
+        alarmBean.setDescription(description);
+
+        return alarmBean;
+    }
+
+    @Override
+    public void write(WriteBuffer buffer, AlarmBean attribute) {
+        stringSerializer.write(buffer, attribute.getId());
+        longSerializer.write(buffer, attribute.getTime());
+        integerSerializer.write(buffer, attribute.getSeverity().getValue());
+        stringSerializer.write(buffer, attribute.getInventoryObjectId());
+        stringSerializer.write(buffer, attribute.getInventoryObjectType());
+        stringSerializer.write(buffer, attribute.getSummary());
+        stringSerializer.write(buffer, attribute.getDescription());
+    }
+
+    @Override
+    public void verifyAttribute(AlarmBean value) {
+        Objects.requireNonNull(value);
+        Objects.requireNonNull(value.getId());
+        Objects.requireNonNull(value.getSeverity());
+        Objects.requireNonNull(value.getInventoryObjectId());
+        Objects.requireNonNull(value.getInventoryObjectType());
+        // TODO: Are summary and desc mandatory?
+        Objects.requireNonNull(value.getSummary());
+        Objects.requireNonNull(value.getDescription());
+    }
+}

--- a/features/graph/janusgraph/src/main/java/org/opennms/oce/features/graph/janusgraph/ManagedJanusGraph.java
+++ b/features/graph/janusgraph/src/main/java/org/opennms/oce/features/graph/janusgraph/ManagedJanusGraph.java
@@ -1,0 +1,297 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.features.graph.janusgraph;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphFactory;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.opennms.oce.datasource.api.Alarm;
+import org.opennms.oce.datasource.api.InventoryObject;
+import org.opennms.oce.datasource.api.InventoryObjectPeerRef;
+import org.opennms.oce.datasource.api.InventoryObjectRelativeRef;
+import org.opennms.oce.datasource.api.ResourceKey;
+import org.opennms.oce.features.graph.api.AbstractManagedGraph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class ManagedJanusGraph extends AbstractManagedGraph {
+    private static final Logger LOG = LoggerFactory.getLogger(ManagedJanusGraph.class);
+    private final JanusGraph janusGraph;
+    private final GraphTraversalSource g;
+    private final Set<InventoryObject> deferredIos = new HashSet<>();
+
+    // The keys used to associate properties to JanusGraph elements
+    private static final String KEY_RESOURCE_KEY = "resourceKey";
+    private static final String KEY_INVENTORY_OBJECT_ID = "inventoryObjectId";
+    private static final String KEY_ALARMS = "alarms";
+
+    public ManagedJanusGraph(String storageBackend) {
+        janusGraph = JanusGraphFactory.build()
+                // Set the configurable properties
+                .set("storage.backend", storageBackend)
+                // The following properties should remain hardcoded
+                .set("attributes.custom.attribute1.attribute-class", "org.opennms.oce.datasource.common.AlarmBean")
+                .set("attributes.custom.attribute1.serializer-class",
+                        "org.opennms.oce.features.graph.janusgraph.AlarmBeanSerializer")
+                .open();
+
+        // Set up the vertex properties
+        JanusGraphManagement mgmt = janusGraph.openManagement();
+        mgmt.makePropertyKey(KEY_RESOURCE_KEY).dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        mgmt.makePropertyKey(KEY_INVENTORY_OBJECT_ID).dataType(String.class).cardinality(Cardinality.SINGLE).make();
+        mgmt.makePropertyKey(KEY_ALARMS).dataType(Object.class).cardinality(Cardinality.SET).make();
+        mgmt.commit();
+
+        g = janusGraph.traversal();
+    }
+
+    @Override
+    public synchronized void addInventory(Collection<InventoryObject> inventory) {
+        addInventory(inventory, false);
+    }
+
+    private synchronized void addInventory(Collection<InventoryObject> inventory, boolean isDeferred) {
+        // Start off by adding vertices to the graph for any new object
+        for (InventoryObject io : inventory) {
+            ResourceKey resourceKey = getResourceKeyFor(io);
+            addVertex(resourceKey, io.getId());
+        }
+
+        // Now handle the relationships
+        for (InventoryObject io : inventory) {
+            ResourceKey resourceKey = getResourceKeyFor(io);
+            //noinspection OptionalGetWithoutIsPresent
+            Vertex vertex = getVertex(resourceKey).get();
+
+            if (!buildParentRelationships(io, resourceKey, vertex) || !buildPeerRelationships(io, resourceKey,
+                    vertex) || !buildRelativeRelationships(io, resourceKey, vertex)) {
+                if (!isDeferred) {
+                    deferredIos.add(io);
+                }
+            } else if (isDeferred) {
+                deferredIos.remove(io);
+            }
+        }
+
+        if (!isDeferred) {
+            handleDeferredIos();
+        }
+    }
+
+    private boolean buildParentRelationships(InventoryObject io, ResourceKey resourceKey, Vertex vertex) {
+        ResourceKey parentResourceKey = getResourceKeyForParent(io);
+
+        if (parentResourceKey != null) {
+            Optional<Vertex> parentVertex = getVertex(parentResourceKey);
+
+            if (!parentVertex.isPresent()) {
+                LOG.info("No existing vertex found for parent with resource key '{}' on vertex with resource key " +
+                        "'{}'. Deferring edge association.", parentResourceKey, resourceKey);
+
+                return false;
+            }
+
+            if (!areVerticesAdjacent(vertex, parentVertex.get())) {
+                LOG.debug("Adding edge between child: {} and parent: {}", vertex, parentVertex.get());
+                vertex.addEdge("parent", parentVertex.get(), "id", edgeIdGenerator.getAndIncrement(),
+                        "weight", io.getWeightToParent());
+            }
+        }
+
+        return true;
+    }
+
+    private boolean buildPeerRelationships(InventoryObject io, ResourceKey resourceKey, Vertex vertex) {
+        for (InventoryObjectPeerRef peerRef : io.getPeers()) {
+            ResourceKey peerResourceKey = getResourceKeyForPeer(peerRef);
+            Optional<Vertex> peerVertex = getVertex(peerResourceKey);
+
+            if (!peerVertex.isPresent()) {
+                LOG.info("No existing vertex found for peer with resource key '{}' on vertex with resource key " +
+                        "'{}'. Deferring edge association.", peerResourceKey, resourceKey);
+
+                return false;
+            }
+
+            if (!areVerticesAdjacent(vertex, peerVertex.get())) {
+                LOG.debug("Adding edge between peers A: {} and Z: {}", peerVertex.get(), vertex);
+                vertex.addEdge("peer", peerVertex.get(), "id",
+                        edgeIdGenerator.getAndIncrement(), "weight", peerRef.getWeight());
+            }
+        }
+
+        return true;
+    }
+
+    private boolean buildRelativeRelationships(InventoryObject io, ResourceKey resourceKey, Vertex vertex) {
+        for (InventoryObjectRelativeRef relativeRef : io.getRelatives()) {
+            ResourceKey relativeResourceKey = getResourceKeyForPeer(relativeRef);
+            Optional<Vertex> relativeVertex = getVertex(relativeResourceKey);
+
+            if (!relativeVertex.isPresent()) {
+                LOG.info("No existing vertex found for relative with resource key '{}' on vertex with resource " +
+                        "key '{}'. Deferring edge association.", relativeResourceKey, resourceKey);
+
+                return false;
+            }
+
+            if (!areVerticesAdjacent(vertex, relativeVertex.get())) {
+                LOG.debug("Adding edge between relatives A: {} and Z: {}", relativeVertex.get(),
+                        vertex);
+                vertex.addEdge("relative", relativeVertex.get(), "id",
+                        edgeIdGenerator.getAndIncrement(), "weight", relativeRef.getWeight());
+            }
+        }
+
+        return true;
+    }
+
+    private void handleDeferredIos() {
+        if (deferredIos.isEmpty()) {
+            return;
+        }
+
+        addInventory(Collections.unmodifiableCollection(deferredIos), true);
+    }
+
+    @Override
+    public void removeInventory(Collection<InventoryObject> inventory) {
+        for (InventoryObject io : inventory) {
+            ResourceKey resourceKey = getResourceKeyFor(io);
+            getVertex(resourceKey).ifPresent(Element::remove);
+            deferredIos.remove(io);
+        }
+    }
+
+    @Override
+    public void addOrUpdateAlarm(Alarm alarm) {
+        if (alarm.getInventoryObjectType() == null || alarm.getInventoryObjectId() == null) {
+            LOG.info("Alarm with id: {} is not associated with any resource. It will not be added to the graph.",
+                    alarm.getId());
+            return;
+        }
+
+        ResourceKey resourceKey = getResourceKeyFor(alarm);
+
+        if (!getVertex(resourceKey).isPresent()) {
+            addVertex(resourceKey, alarm.getInventoryObjectId());
+            LOG.info("No existing vertex was found with resource key: {} for alarm with id: {}. Creating a new  " +
+                    "vertex.", resourceKey, alarm.getId());
+            handleDeferredIos();
+        }
+
+        // Add this alarm to the vertex replacing an existing alarm that is being updated if necessary
+        getVertex(resourceKey).get().property(KEY_ALARMS, alarm);
+    }
+
+    @Override
+    public void garbageCollectAlarms(long currentTimeMs, long problemTimeoutMs, long clearTimeoutMs) {
+        long problemCutoffMs = currentTimeMs - problemTimeoutMs;
+        long clearCutoffMs = currentTimeMs - clearTimeoutMs;
+
+        g.V().has(KEY_ALARMS).forEachRemaining(vertexWithAlarms -> {
+            LOG.debug("GCing vertex {}", vertexWithAlarms);
+
+            vertexWithAlarms.properties(KEY_ALARMS).forEachRemaining(alarmProperty -> {
+                Alarm alarm = (Alarm) alarmProperty.value();
+                LOG.trace("Considering alarm {} for GC", alarm);
+
+                if (alarm.isClear() && alarm.getTime() < clearCutoffMs) {
+                    LOG.debug("GCing cleared alarm with id: {}, alarm time is: {} " +
+                                    "which is before the cutoff time of: {}", alarm.getId(), new Date(alarm.getTime()),
+                            new Date(clearCutoffMs));
+                    alarmProperty.remove();
+                } else if (!alarm.isClear() && alarm.getTime() < problemCutoffMs) {
+                    LOG.debug("GCing problem alarm with id: {}, alarm time is: {} " +
+                                    "which is before the cutoff time of: {}", alarm.getId(), new Date(alarm.getTime()),
+                            new Date(problemCutoffMs));
+                    alarmProperty.remove();
+                }
+            });
+        });
+    }
+
+    @Override
+    public void close() {
+        janusGraph.close();
+    }
+
+    private void addVertex(ResourceKey resourceKey, String inventoryObjectId) {
+        String label = resourceKey.toString();
+
+        // To enforce a 1:1 mapping between resource keys and vertices
+        if (g.V().hasLabel(label).hasNext()) {
+            throw new IllegalArgumentException("A vertex with label '" + label + "' already exists");
+        }
+
+        LOG.debug("Adding vertex with resource key: {} for inventory object id: {}", resourceKey, inventoryObjectId);
+        Vertex v = g.addV(label).next();
+        v.property(KEY_RESOURCE_KEY, resourceKey);
+        v.property(KEY_INVENTORY_OBJECT_ID, inventoryObjectId);
+    }
+
+    private Optional<Vertex> getVertex(ResourceKey resourceKey) {
+        return g.V().hasLabel(resourceKey.toString()).tryNext();
+    }
+
+    private boolean areVerticesAdjacent(Vertex vertexA, Vertex vertexB) {
+        boolean isAdjacent = g.V()
+                .is(vertexA)
+                .both()
+                .is(vertexB)
+                .hasNext();
+
+        LOG.debug("{} is {}adjacent to {}", vertexA.label(), isAdjacent ? "" : "not ", vertexB.label());
+        
+        return isAdjacent;
+    }
+
+    @Override
+    public int hashCode() {
+        return janusGraph.hashCode();
+    }
+
+    @VisibleForTesting
+    GraphTraversalSource getGraphTraversal() {
+        return g;
+    }
+}

--- a/features/graph/janusgraph/src/main/resources/blueprint.xml
+++ b/features/graph/janusgraph/src/main/resources/blueprint.xml
@@ -1,0 +1,15 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0">
+    <!-- Configuration properties -->
+    <cm:property-placeholder id="janusGraphProperties" persistent-id="org.opennms.oce.features.graph.janusgraph"
+                             update-strategy="reload">
+        <cm:default-properties>
+            <cm:property name="storageBackend" value="inmemory"/>
+        </cm:default-properties>
+    </cm:property-placeholder>
+    <bean id="managedJanusGraph" class="org.opennms.oce.features.graph.janusgraph.ManagedJanusGraph">
+        <argument value="${storageBackend}"/>
+    </bean>
+    <service ref="managedJanusGraph" interface="org.opennms.oce.features.graph.api.ManagedGraph"/>
+</blueprint>

--- a/features/graph/janusgraph/src/main/resources/blueprint.xml
+++ b/features/graph/janusgraph/src/main/resources/blueprint.xml
@@ -5,11 +5,12 @@
     <cm:property-placeholder id="janusGraphProperties" persistent-id="org.opennms.oce.features.graph.janusgraph"
                              update-strategy="reload">
         <cm:default-properties>
-            <cm:property name="storageBackend" value="inmemory"/>
+            <!-- TODO: What should the default path be? -->
+            <cm:property name="storagePropertiesFilePath" value="/opt/example.properties"/>
         </cm:default-properties>
     </cm:property-placeholder>
     <bean id="managedJanusGraph" class="org.opennms.oce.features.graph.janusgraph.ManagedJanusGraph">
-        <argument value="${storageBackend}"/>
+        <argument value="${storagePropertiesFilePath}"/>
     </bean>
     <service ref="managedJanusGraph" interface="org.opennms.oce.features.graph.api.ManagedGraph"/>
 </blueprint>

--- a/features/graph/janusgraph/src/main/resources/cassandra.properties
+++ b/features/graph/janusgraph/src/main/resources/cassandra.properties
@@ -1,0 +1,9 @@
+storage.backend=cql
+storage.cql.keyspace=janusgraph
+storage.hostname=127.0.0.1
+index.search.backend=elasticsearch
+index.search.hostname=127.0.0.1:9200
+# Do not edit the below
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+attributes.custom.attribute1.attribute-class=org.opennms.oce.datasource.common.AlarmBean
+attributes.custom.attribute1.serializer-class=org.opennms.oce.features.graph.janusgraph.AlarmBeanSerializer

--- a/features/graph/janusgraph/src/main/resources/cassandra.yaml
+++ b/features/graph/janusgraph/src/main/resources/cassandra.yaml
@@ -1,0 +1,28 @@
+# Minimal configuration for testing using cassandraunit
+cluster_name: 'JanusGraph'
+authenticator: AllowAllAuthenticator
+authorizer: AllowAllAuthorizer
+permissions_validity_in_ms: 2000
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+data_file_directories:
+- /tmp/cassandra/data
+commitlog_directory: /tmp/cassandra/commitlog
+saved_caches_directory: /tmp/cassandra/caches
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+commitlog_segment_size_in_mb: 32
+seed_provider:
+- class_name: org.apache.cassandra.locator.SimpleSeedProvider
+  parameters:
+  - seeds: "127.0.0.1"
+storage_port: 7000
+ssl_storage_port: 7001
+listen_address: localhost
+start_native_transport: true
+native_transport_port: 9042
+start_rpc: true
+rpc_address: localhost
+rpc_port: 9160
+rpc_keepalive: true
+rpc_server_type: sync
+endpoint_snitch: SimpleSnitch

--- a/features/graph/janusgraph/src/main/resources/inmemory.properties
+++ b/features/graph/janusgraph/src/main/resources/inmemory.properties
@@ -1,0 +1,5 @@
+storage.backend=inmemory
+# Do not edit the below
+gremlin.graph=org.janusgraph.core.JanusGraphFactory
+attributes.custom.attribute1.attribute-class=org.opennms.oce.datasource.common.AlarmBean
+attributes.custom.attribute1.serializer-class=org.opennms.oce.features.graph.janusgraph.AlarmBeanSerializer

--- a/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/CassandraESIT.java
+++ b/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/CassandraESIT.java
@@ -65,6 +65,7 @@ public class CassandraESIT {
     private GraphTraversalSource g;
     private static Session cassandraSession;
     private static final EmbeddedElastic embeddedElastic = EmbeddedElastic.builder()
+            // TODO: Do we want to test a specific version?
             .withElasticVersion("5.0.0")
             .withSetting(PopularProperties.HTTP_PORT, 9200)
             .withSetting(PopularProperties.CLUSTER_NAME, "janusgraph")
@@ -74,7 +75,11 @@ public class CassandraESIT {
     public static void start() throws ConfigurationException, IOException, TTransportException,
             InterruptedException {
         EmbeddedCassandraServerHelper.startEmbeddedCassandra("cassandra.yaml");
-        cassandraSession = Cluster.builder().addContactPoints("127.0.0.1").withPort(9042).build().connect();
+        cassandraSession = Cluster.builder()
+                .addContactPoints("127.0.0.1")
+                .withPort(9042)
+                .build()
+                .connect();
         embeddedElastic.start();
     }
 

--- a/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/CassandraESIT.java
+++ b/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/CassandraESIT.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.features.graph.janusgraph;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.thrift.transport.TTransportException;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opennms.oce.datasource.api.SituationHandler;
+import org.opennms.oce.driver.test.MockInventoryBuilder;
+import org.opennms.oce.driver.test.MockInventoryType;
+import org.opennms.oce.engine.cluster.ClusterEngine;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+
+import pl.allegro.tech.embeddedelasticsearch.EmbeddedElastic;
+import pl.allegro.tech.embeddedelasticsearch.PopularProperties;
+
+/**
+ * Integration tests for {@link ManagedJanusGraph} using Cassandra/Elasticsearch as the storage backend.
+ */
+public class CassandraESIT {
+    private static final String propertiesFilesName = "cassandra.properties";
+    private final ClusterEngine engine = new ClusterEngine();
+    private ManagedJanusGraph janusGraph;
+    private GraphTraversalSource g;
+    private static Session cassandraSession;
+    private static final EmbeddedElastic embeddedElastic = EmbeddedElastic.builder()
+            .withElasticVersion("5.0.0")
+            .withSetting(PopularProperties.HTTP_PORT, 9200)
+            .withSetting(PopularProperties.CLUSTER_NAME, "janusgraph")
+            .build();
+
+    @BeforeClass
+    public static void start() throws ConfigurationException, IOException, TTransportException,
+            InterruptedException {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra("cassandra.yaml");
+        cassandraSession = Cluster.builder().addContactPoints("127.0.0.1").withPort(9042).build().connect();
+        embeddedElastic.start();
+    }
+
+    @AfterClass
+    public static void stop() {
+        embeddedElastic.stop();
+        cassandraSession.getCluster().close();
+    }
+
+    @After
+    public void closeGraphs() {
+        engine.getGraphManager().close();
+    }
+
+    @Before
+    public void init() {
+        // Start with a fresh Cassandra
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+
+        engine.registerSituationHandler(mock(SituationHandler.class));
+        engine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+        // Start with a fresh JanusGraph instance
+        janusGraph = new ManagedJanusGraph(getClass().getClassLoader()
+                .getResource(propertiesFilesName).getPath());
+        engine.getGraphManager().onBind(janusGraph, Collections.emptyMap());
+    }
+
+    @Test
+    public void testGraphPersists() {
+        // Add vertices and edges to the graph
+        engine.onInventoryAdded(new MockInventoryBuilder()
+                .withInventoryObject(MockInventoryType.COMPONENT, "a")
+                .withInventoryObject(MockInventoryType.COMPONENT, "b", MockInventoryType.COMPONENT, "a")
+                .getInventory());
+
+        // Verify we have the right amount of vertices and edges
+        g = janusGraph.getGraphTraversal();
+        assertThat(g.E().count().next(), equalTo(1L));
+        assertThat(g.V().count().next(), equalTo(2L));
+
+        // Remove the JanusGraph instance and reconnect with a new one
+        engine.getGraphManager().onUnbind(janusGraph, Collections.emptyMap());
+        janusGraph = new ManagedJanusGraph(getClass().getClassLoader()
+                .getResource(propertiesFilesName).getPath());
+        engine.getGraphManager().onBind(janusGraph, Collections.emptyMap());
+
+        // Verify we still have the right amount of vertices and edges
+        g = janusGraph.getGraphTraversal();
+        assertThat(g.E().count().next(), equalTo(1L));
+        assertThat(g.V().count().next(), equalTo(2L));
+    }
+}

--- a/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/JanusGraphTest.java
+++ b/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/JanusGraphTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.features.graph.janusgraph;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.junit.Test;
+import org.opennms.oce.datasource.api.Alarm;
+import org.opennms.oce.datasource.api.Severity;
+import org.opennms.oce.datasource.api.SituationHandler;
+import org.opennms.oce.datasource.common.AlarmBean;
+import org.opennms.oce.driver.test.MockInventoryBuilder;
+import org.opennms.oce.driver.test.MockInventoryType;
+import org.opennms.oce.engine.cluster.ClusterEngine;
+
+public class JanusGraphTest {
+    private static final String INVENTORY_OBJECT_ID = "inventoryObjectId";
+    private static final String KEY_ALARMS = "alarms";
+    private final ClusterEngine engine = new ClusterEngine();
+    private final ManagedJanusGraph janusGraph = new ManagedJanusGraph("inmemory");
+    private GraphTraversalSource g;
+
+    @Test
+    public void testGraphManagerWithJanusGraph() {
+        engine.registerSituationHandler(mock(SituationHandler.class));
+        engine.init(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+        // Explicitly add the graph to the Graph Manager
+        engine.getGraphManager().onBind(janusGraph, Collections.emptyMap());
+
+        // Add vertices and edges to the graph
+        engine.onInventoryAdded(new MockInventoryBuilder()
+                .withInventoryObject(MockInventoryType.COMPONENT, "a")
+                .withInventoryObject(MockInventoryType.COMPONENT, "b", MockInventoryType.COMPONENT, "a")
+                .withInventoryObject(MockInventoryType.COMPONENT, "c")
+                .withInventoryObject(MockInventoryType.COMPONENT, "d")
+                .withInventoryObject(MockInventoryType.COMPONENT, "e")
+                .withPeerRelation(MockInventoryType.COMPONENT, "c", MockInventoryType.COMPONENT, "b",
+                        MockInventoryType.COMPONENT, "d")
+                // Purposely add duplicate peer relations to make sure they don't result in duplicated edges
+                .withPeerRelation(MockInventoryType.COMPONENT, "c", MockInventoryType.COMPONENT, "b",
+                        MockInventoryType.COMPONENT, "d")
+                .withRelativeRelation(MockInventoryType.COMPONENT, "e", MockInventoryType.COMPONENT, "d")
+                .getInventory());
+
+        AlarmBean alarm1 = createAndProcessAlarm("alarm1", "a");
+        AlarmBean alarm2 = createAndProcessAlarm("alarm2", "a");
+        engine.onTick(alarm2.getTime());
+
+        g = janusGraph.getGraphTraversal();
+
+        // Verify we have the right amount of vertices, edges and alarms
+        assertThat(g.E().count().next(), equalTo(4L));
+        assertThat(g.V().count().next(), equalTo(5L));
+        assertThat(numAlarmsOnVertex("a"), equalTo(2L));
+
+        // Update the alarm and verify it did not result in a new alarm being created and that the update is reflected
+        alarm1.setSeverity(Severity.CRITICAL);
+        long newTime = alarm1.getTime() + 1000;
+        alarm1.setTime(newTime);
+        engine.onAlarmCreatedOrUpdated(alarm1);
+        assertThat(numAlarmsOnVertex("a"), equalTo(2L));
+        boolean alarm1SeverityUpdated = getVertexTraversal("a").properties(KEY_ALARMS).toStream()
+                .anyMatch(alarmProperty -> {
+                    Alarm alarm = (Alarm) alarmProperty.value();
+                    return alarm.getId().equals("alarm1") && alarm.getSeverity() == Severity.CRITICAL &&
+                            alarm.getTime() == newTime;
+                });
+        assertThat(alarm1SeverityUpdated, equalTo(true));
+
+        // Make sure alarms get GC on clear
+        alarm1.setSeverity(Severity.CLEARED);
+        engine.onAlarmCleared(alarm1);
+        engine.tick(alarm1.getTime() + engine.clearTimeoutMs + 1);
+        assertThat(numAlarmsOnVertex("a"), equalTo(1L));
+
+        // Make sure alarms get GC on timeout
+        alarm2.setSeverity(Severity.CRITICAL);
+        // Need to update the alarm so we are eligible to GC
+        engine.onAlarmCreatedOrUpdated(alarm2);
+        engine.tick(Long.MAX_VALUE);
+        assertThat(numAlarmsOnVertex("a"), equalTo(0L));
+
+        engine.getGraphManager().onUnbind(janusGraph, Collections.emptyMap());
+    }
+
+    private GraphTraversal<org.apache.tinkerpop.gremlin.structure.Vertex,
+            org.apache.tinkerpop.gremlin.structure.Vertex> getVertexTraversal(String inventoryObjectId) {
+        return g.V().has(INVENTORY_OBJECT_ID, inventoryObjectId);
+    }
+
+    private long numAlarmsOnVertex(String inventoryObjectId) {
+        return getVertexTraversal(inventoryObjectId).properties(KEY_ALARMS).count().next();
+    }
+
+    private AlarmBean createAndProcessAlarm(String alarmId, String inventoryId) {
+        AlarmBean alarm = new AlarmBean(alarmId);
+        alarm.setSeverity(Severity.MAJOR);
+        alarm.setInventoryObjectId(inventoryId);
+        alarm.setInventoryObjectType(MockInventoryType.COMPONENT.getType());
+        alarm.setDescription("Description for alarm " + alarmId);
+        alarm.setSummary("Summary for alarm " + alarmId);
+        engine.onAlarmCreatedOrUpdated(alarm);
+
+        return alarm;
+    }
+}

--- a/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/ManagedJanusGraphTest.java
+++ b/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/ManagedJanusGraphTest.java
@@ -45,11 +45,12 @@ import org.opennms.oce.driver.test.MockInventoryBuilder;
 import org.opennms.oce.driver.test.MockInventoryType;
 import org.opennms.oce.engine.cluster.ClusterEngine;
 
-public class JanusGraphTest {
+public class ManagedJanusGraphTest {
     private static final String INVENTORY_OBJECT_ID = "inventoryObjectId";
     private static final String KEY_ALARMS = "alarms";
     private final ClusterEngine engine = new ClusterEngine();
-    private final ManagedJanusGraph janusGraph = new ManagedJanusGraph("inmemory");
+    private final ManagedJanusGraph janusGraph = new ManagedJanusGraph(getClass().getClassLoader()
+            .getResource("inmemory.properties").getPath());
     private GraphTraversalSource g;
 
     @Test
@@ -113,7 +114,7 @@ public class JanusGraphTest {
         engine.tick(Long.MAX_VALUE);
         assertThat(numAlarmsOnVertex("a"), equalTo(0L));
 
-        engine.getGraphManager().onUnbind(janusGraph, Collections.emptyMap());
+        engine.getGraphManager().close();
     }
 
     private GraphTraversal<org.apache.tinkerpop.gremlin.structure.Vertex,

--- a/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/ManagedJanusGraphTest.java
+++ b/features/graph/janusgraph/src/test/java/org/opennms/oce/features/graph/janusgraph/ManagedJanusGraphTest.java
@@ -93,7 +93,8 @@ public class ManagedJanusGraphTest {
         alarm1.setTime(newTime);
         engine.onAlarmCreatedOrUpdated(alarm1);
         assertThat(numAlarmsOnVertex("a"), equalTo(2L));
-        boolean alarm1SeverityUpdated = getVertexTraversal("a").properties(KEY_ALARMS).toStream()
+        boolean alarm1SeverityUpdated = getVertexTraversal("a").properties(KEY_ALARMS)
+                .toStream()
                 .anyMatch(alarmProperty -> {
                     Alarm alarm = (Alarm) alarmProperty.value();
                     return alarm.getId().equals("alarm1") && alarm.getSeverity() == Severity.CRITICAL &&

--- a/features/graph/pom.xml
+++ b/features/graph/pom.xml
@@ -12,9 +12,10 @@
 
     <modules>
         <module>api</module>
-	<module>common</module>
-	<module>graphml</module>
-	<module>rest</module>
-	<module>shell</module>
+        <module>common</module>
+        <module>graphml</module>
+        <module>rest</module>
+        <module>shell</module>
+        <module>janusgraph</module>
     </modules>
 </project>

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -129,6 +129,14 @@
         <bundle>mvn:org.opennms.oce.features.graph/org.opennms.oce.features.graph.rest/${project.version}</bundle>
     </feature>
 
+    <feature name="oce-features-graph-janusgraph" description="OCE :: Features :: Graph :: JanusGraph" version="${project.version}">
+        <feature dependency="true" version="${project.version}">oce-features-graph-api</feature>
+        <!-- TODO: The following bundle gives me an error that it does not contain a manifest when I attempt to install
+         this feature -->
+        <bundle dependency="true">mvn:org.janusgraph/janusgraph-core/0.3.1</bundle>
+        <bundle>mvn:org.opennms.oce.features.graph/org.opennms.oce.features.graph.janusgraph/${project.version}</bundle>
+    </feature>
+
     <!-- Situation Processors -->
 
     <feature name="oce-processor-api" description="OCE :: Processor :: API" version="${project.version}">


### PR DESCRIPTION
**Don't merge or review before #38**

This PR builds on #38 to allow using Cassandra/Elasticsearch as a persistent backend for the JanusGraph implementation. It also updates the ManagedJanusGraph class to commit transactions and use indexing so that is plays nice with persistent storage.

With this PR the JanusGraph feature will now require a properties file be specified that describes the storage model (inmemory or Cassandra/ES).

This PR should be re-targeted to the master branch after #38 is merged.