### PR TITLE
OCE-25: Update situations with latest copy of alarm

### DIFF
--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/SituationBean.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/SituationBean.java
@@ -29,10 +29,12 @@
 package org.opennms.oce.datasource.common;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.opennms.oce.datasource.api.Alarm;
 import org.opennms.oce.datasource.api.ResourceKey;
@@ -45,7 +47,7 @@ public class SituationBean implements Situation {
 
     private Severity severity = Severity.INDETERMINATE;
     private List<ResourceKey> resourceKeys = new ArrayList<>();
-    private Set<Alarm> alarms = new LinkedHashSet<>();
+    private Map<String, Alarm> alarms = new HashMap<>();
     private String diagnosticText;
 
     public SituationBean() {
@@ -60,7 +62,7 @@ public class SituationBean implements Situation {
         this.creationTime = situation.getCreationTime();
         this.severity = situation.getSeverity();
         this.resourceKeys.addAll(situation.getResourceKeys());
-        this.alarms.addAll(situation.getAlarms());
+        this.alarms.putAll(situation.getAlarms().stream().collect(Collectors.toMap(Alarm::getId, a -> a)));
         this.diagnosticText = situation.getDiagnosticText();
     }
 
@@ -97,15 +99,15 @@ public class SituationBean implements Situation {
 
     @Override
     public Set<Alarm> getAlarms() {
-        return alarms;
+        return alarms.values().stream().collect(Collectors.toSet());
     }
 
     public void setAlarms(Set<Alarm> alarms) {
-        this.alarms = alarms;
+        this.alarms = alarms.stream().collect(Collectors.toMap(Alarm::getId, a -> a));
     }
 
     public void addAlarm(Alarm alarm) {
-        alarms.add(alarm);
+        alarms.put(alarm.getId(), alarm);
     }
 
     public Severity getSeverity() {

--- a/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEngineSituationTest.java
+++ b/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEngineSituationTest.java
@@ -46,6 +46,8 @@ import org.opennms.oce.datasource.api.SituationHandler;
 import org.opennms.oce.datasource.common.AlarmBean;
 import org.opennms.oce.datasource.common.SituationBean;
 
+import com.google.common.collect.Iterables;
+
 public class ClusterEngineSituationTest implements SituationHandler {
 
     private List<Situation> triggeredSituations = new ArrayList<>();
@@ -102,6 +104,20 @@ public class ClusterEngineSituationTest implements SituationHandler {
         // The situation should have the same id as the initial situation
         assertThat(triggeredSituations.get(0).getId(), equalTo(initialSituation.getId()));
         assertThat(triggeredSituations.get(0).getAlarms(), containsInAnyOrder(a1, a2, a3));
+
+        // Assert that the situation alarm has been updated and has the correct time
+        AlarmBean a1_ = new AlarmBean();
+        a1_.setId("a1");
+        a1_.setInventoryObjectId("n1");
+        a1_.setInventoryObjectType("node");
+        a1_.setTime(100L);
+        alarms = Arrays.asList(a1_, a2, a3);
+        clusterEngine = new ClusterEngine();
+        clusterEngine.init(alarms, Collections.singletonList(initialSituation), Collections.emptyList());
+        clusterEngine.registerSituationHandler(this);
+        clusterEngine.tick(clusterEngine.getTickResolutionMs());
+        assertThat(Iterables.getLast(triggeredSituations).getAlarms().stream().filter(a -> a.getId().equals("a1")).findFirst().get().getTime(),
+                   equalTo(100L));
     }
 
     @Override

--- a/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEngineSituationTest.java
+++ b/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/ClusterEngineSituationTest.java
@@ -102,22 +102,27 @@ public class ClusterEngineSituationTest implements SituationHandler {
         assertThat(triggeredSituations, hasSize(1));
 
         // The situation should have the same id as the initial situation
-        assertThat(triggeredSituations.get(0).getId(), equalTo(initialSituation.getId()));
-        assertThat(triggeredSituations.get(0).getAlarms(), containsInAnyOrder(a1, a2, a3));
+        assertThat(Iterables.getLast(triggeredSituations).getId(), equalTo(initialSituation.getId()));
+        assertThat(Iterables.getLast(triggeredSituations).getAlarms(), containsInAnyOrder(a1, a2, a3));
+        assertThat(Iterables.getLast(triggeredSituations).getDiagnosticText(),
+                   equalTo("The 3 alarms happened within 0.00 seconds across 1 vertices."));
 
         // Assert that the situation alarm has been updated and has the correct time
         AlarmBean a1_ = new AlarmBean();
         a1_.setId("a1");
         a1_.setInventoryObjectId("n1");
         a1_.setInventoryObjectType("node");
-        a1_.setTime(100L);
+        a1_.setTime(10000L);
         alarms = Arrays.asList(a1_, a2, a3);
         clusterEngine = new ClusterEngine();
         clusterEngine.init(alarms, Collections.singletonList(initialSituation), Collections.emptyList());
         clusterEngine.registerSituationHandler(this);
         clusterEngine.tick(clusterEngine.getTickResolutionMs());
         assertThat(Iterables.getLast(triggeredSituations).getAlarms().stream().filter(a -> a.getId().equals("a1")).findFirst().get().getTime(),
-                   equalTo(100L));
+                   equalTo(10000L));
+        assertThat(Iterables.getLast(triggeredSituations).getDiagnosticText(),
+                   equalTo("The 3 alarms happened within 10.00 seconds across 1 vertices."));
+
     }
 
     @Override


### PR DESCRIPTION
This PR changes the behaviour of the Cluster Engine to update the Alarms in the Situation.
This behaviour change also fixes OCE-21 where the issue where the Diagnostic Text of the Situation was incorrect as this was due to the alarms not being updated and having the correct time.

* JIRA: https://issues.opennms.org/browse/OCE-25
* JIRA: https://issues.opennms.org/browse/OCE-21