### PR TITLE
OCE-13: Managed object tagging support for interface related thresholds

### DIFF
--- a/integrations/opennms/extension/src/main/java/org/opennms/oce/opennms/extension/ManagedObjectAlarmExt.java
+++ b/integrations/opennms/extension/src/main/java/org/opennms/oce/opennms/extension/ManagedObjectAlarmExt.java
@@ -59,6 +59,8 @@ public class ManagedObjectAlarmExt implements AlarmPersisterExtension {
     private static final String ENT_PHYSICAL_INDEX_PARM_NAME = "entPhysicalIndex";
     private static final String IFINDEX_PARM_NAME = "ifIndex";
     private static final String IFDESCR_PARM_NAME = "ifDescr";
+    
+    private static final String THRESHOLD_SOURCE = "threshd";
 
     protected static final String A_IFDESCR_PARM_NAME = "aIfDescr";
     protected static final String Z_IFDESCR_PARM_NAME = "zIfDescr";
@@ -102,6 +104,12 @@ public class ManagedObjectAlarmExt implements AlarmPersisterExtension {
             // If we haven't figured out an appropriate type, and the alarm is associated with a node
             // then default to using the 'node' type
             managedObjectType = ManagedObjectType.Node;
+        }
+
+        if (managedObjectType == null && inMemoryEvent.getSource().toLowerCase().contains(THRESHOLD_SOURCE) &&
+                !inMemoryEvent.getParametersByName(IFINDEX_PARM_NAME).isEmpty()) {
+            // If this is an SNMP interface threshold alarm then we can tag it to the appropriate ifIndex
+            managedObjectType = ManagedObjectType.SnmpInterface;
         }
 
         final ManagedObject managedObject = getManagedObjectFor(managedObjectType, alarm, inMemoryEvent);

--- a/integrations/opennms/extension/src/test/java/org/opennms/oce/opennms/extension/ManagedObjectAlarmExtTest.java
+++ b/integrations/opennms/extension/src/test/java/org/opennms/oce/opennms/extension/ManagedObjectAlarmExtTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.opennms.extension;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.dao.SnmpInterfaceDao;
+import org.opennms.integration.api.v1.model.Alarm;
+import org.opennms.integration.api.v1.model.DatabaseEvent;
+import org.opennms.integration.api.v1.model.EventParameter;
+import org.opennms.integration.api.v1.model.InMemoryEvent;
+import org.opennms.integration.api.v1.model.beans.EventParameterBean;
+import org.opennms.oce.opennms.model.ManagedObjectType;
+
+public class ManagedObjectAlarmExtTest {
+    private final ManagedObjectAlarmExt managedObjectAlarmExt = new ManagedObjectAlarmExt(mock(NodeDao.class),
+            mock(SnmpInterfaceDao.class));
+
+    @Test
+    public void testThreshholdAlarm() {
+        Alarm alarm = mock(Alarm.class);
+        InMemoryEvent inMemoryEvent = mock(InMemoryEvent.class);
+        DatabaseEvent databaseEvent = mock(DatabaseEvent.class);
+        
+        when(inMemoryEvent.getSource()).thenReturn("OpenNMS.Threshd.ifHCInOctets");
+        String ifIndex = "1";
+        EventParameter eventParameter = new EventParameterBean("ifIndex", ifIndex);
+        when(inMemoryEvent.getParametersByName("ifIndex")).thenReturn(Collections.singletonList(eventParameter));
+        
+        Alarm updatedalarm = managedObjectAlarmExt.afterAlarmCreated(alarm, inMemoryEvent, databaseEvent);
+        assertThat(ManagedObjectType.fromName(updatedalarm.getManagedObjectType()),
+                is(equalTo(ManagedObjectType.SnmpInterface)));
+        assertThat(updatedalarm.getManagedObjectInstance(), is(equalTo(ifIndex)));
+    }
+}


### PR DESCRIPTION
This PR adds support for tagging SNMP interface threshold alarms with the managed object type & instance so they can be placed on the correct vertices in OCE's Cluster Engine.