### PR TITLE
HZN-1421: Support correlation of alarms triggered by the SNMP interface poller

### DIFF
--- a/integrations/opennms/extension/src/test/java/org/opennms/oce/opennms/extension/ManagedObjectAlarmExtTest.java
+++ b/integrations/opennms/extension/src/test/java/org/opennms/oce/opennms/extension/ManagedObjectAlarmExtTest.java
@@ -52,15 +52,24 @@ public class ManagedObjectAlarmExtTest {
 
     @Test
     public void testThreshholdAlarm() {
+        testSnmpInterfaceAlarm("OpenNMS.Threshd.ifHCInOctets", "ifIndex");
+    }
+
+    @Test
+    public void testSnmpPollerAlarm() {
+        testSnmpInterfaceAlarm("OpenNMS.SnmpPoller.DefaultPollContext", "snmpifindex");
+    }
+
+    private void testSnmpInterfaceAlarm(String source, String parameter) {
         Alarm alarm = mock(Alarm.class);
         InMemoryEvent inMemoryEvent = mock(InMemoryEvent.class);
         DatabaseEvent databaseEvent = mock(DatabaseEvent.class);
-        
-        when(inMemoryEvent.getSource()).thenReturn("OpenNMS.Threshd.ifHCInOctets");
+
+        when(inMemoryEvent.getSource()).thenReturn(source);
         String ifIndex = "1";
-        EventParameter eventParameter = new EventParameterBean("ifIndex", ifIndex);
-        when(inMemoryEvent.getParametersByName("ifIndex")).thenReturn(Collections.singletonList(eventParameter));
-        
+        EventParameter eventParameter = new EventParameterBean(parameter, ifIndex);
+        when(inMemoryEvent.getParametersByName(parameter)).thenReturn(Collections.singletonList(eventParameter));
+
         Alarm updatedalarm = managedObjectAlarmExt.afterAlarmCreated(alarm, inMemoryEvent, databaseEvent);
         assertThat(ManagedObjectType.fromName(updatedalarm.getManagedObjectType()),
                 is(equalTo(ManagedObjectType.SnmpInterface)));


### PR DESCRIPTION
This PR adds support for tagging SNMP interface poller alarms with the managed object type & instance so they can be placed on the correct vertices in OCE's Cluster Engine.