### PR TITLE
HZN-1433: Update integration api to handle alarm feedback without Kafka

### DIFF
--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectAlarmFeedbackDatasource.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectAlarmFeedbackDatasource.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.datasource.opennms.jvm;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.dao.AlarmFeedbackDao;
+import org.opennms.integration.api.v1.feedback.AlarmFeedbackListener;
+import org.opennms.oce.datasource.api.AlarmFeedback;
+import org.opennms.oce.datasource.api.AlarmFeedbackDatasource;
+import org.opennms.oce.datasource.api.AlarmFeedbackHandler;
+import org.opennms.oce.datasource.common.HandlerRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A datasource that provides {@link AlarmFeedback} via the integration API.
+ */
+public class DirectAlarmFeedbackDatasource implements AlarmFeedbackListener, AlarmFeedbackDatasource {
+    private static final Logger LOG = LoggerFactory.getLogger(DirectAlarmFeedbackDatasource.class);
+
+    /**
+     * Provided via the integration api and used to retrieve the current feedback on {@link #init}.
+     */
+    private final AlarmFeedbackDao feedbackDao;
+
+    /**
+     * A lock that prevents callbacks from being processed before we have finished {@link #init}.
+     */
+    private final CountDownLatch initLock = new CountDownLatch(1);
+
+    /**
+     * A fair {@link ReadWriteLock} to ensure order of execution is preserved during calls to {@link #onFeedback}.
+     */
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock(true);
+
+    /**
+     * The registry of all currently registered handlers interested in feedback.
+     */
+    private final HandlerRegistry<AlarmFeedbackHandler> feedbackHandlers = new HandlerRegistry<>();
+
+    /**
+     * A set of all feedback populated initially on init by retrieving via the {@link AlarmFeedbackDao} and
+     * subsequently kept up to date via calls to {@link #onFeedback}.
+     */
+    private final Set<AlarmFeedback> feedback = new LinkedHashSet<>();
+
+    /**
+     * A cached immutable copy of the feedback to return to clients (lazily initialized).
+     */
+    private ImmutableList<AlarmFeedback> feedbackCache;
+
+    /**
+     * Whether or not the cached view of feedback is current.
+     */
+    private boolean cacheCurrent = false;
+
+    /**
+     * @param feedbackDao used to retrieve the current feedback
+     */
+    public DirectAlarmFeedbackDatasource(AlarmFeedbackDao feedbackDao) {
+        this.feedbackDao = Objects.requireNonNull(feedbackDao);
+    }
+
+    /**
+     * On init we will populate our feedback cache by retrieving all current feedback from the {@link AlarmFeedbackDao}.
+     */
+    public void init() {
+        feedback.addAll(feedbackDao.getFeedback()
+                .stream()
+                .map(Mappers::toAlarmFeedback)
+                .collect(Collectors.toList()));
+        initLock.countDown();
+    }
+
+    @Override
+    public void onFeedback(org.opennms.integration.api.v1.model.AlarmFeedback feedback) {
+        rwLock.writeLock().lock();
+        try {
+            initLock.await();
+            AlarmFeedback newFeedback = Mappers.toAlarmFeedback(feedback);
+            this.feedback.add(newFeedback);
+            feedbackHandlers.forEach(handler -> handler.handleAlarmFeedback(newFeedback));
+            cacheCurrent = false;
+        } catch (InterruptedException ignore) {
+            LOG.debug("Interrupted while waiting for init lock.");
+            Thread.currentThread().interrupt();
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public List<AlarmFeedback> getAlarmFeedback() {
+        if (!cacheCurrent) {
+            rwLock.readLock().lock();
+            try {
+                initLock.await();
+                feedbackCache = ImmutableList.copyOf(feedback);
+                cacheCurrent = true;
+            } catch (InterruptedException ignore) {
+                LOG.debug("Interrupted while waiting for init lock.");
+                Thread.currentThread().interrupt();
+            } finally {
+                rwLock.readLock().unlock();
+            }
+        }
+
+        return feedbackCache;
+    }
+
+    @Override
+    public List<AlarmFeedback> getAlarmFeedbackAndRegisterHandler(AlarmFeedbackHandler handler) {
+        registerHandler(handler);
+        return getAlarmFeedback();
+    }
+
+    @Override
+    public void registerHandler(AlarmFeedbackHandler handler) {
+        feedbackHandlers.register(handler);
+    }
+
+    @Override
+    public void unregisterHandler(AlarmFeedbackHandler handler) {
+        feedbackHandlers.unregister(handler);
+    }
+
+    @Override
+    public void waitUntilReady() {
+        // pass
+    }
+}

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectAlarmFeedbackDatasource.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectAlarmFeedbackDatasource.java
@@ -28,7 +28,6 @@
 
 package org.opennms.oce.datasource.opennms.jvm;
 
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/Mappers.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/Mappers.java
@@ -36,11 +36,16 @@ import org.opennms.integration.api.v1.model.InMemoryEvent;
 import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.beans.InMemoryEventBean;
 import org.opennms.oce.datasource.api.Alarm;
+import org.opennms.oce.datasource.api.AlarmFeedback;
+import org.opennms.oce.datasource.api.FeedbackType;
 import org.opennms.oce.datasource.api.InventoryObject;
 import org.opennms.oce.datasource.api.Severity;
 import org.opennms.oce.datasource.api.Situation;
 import org.opennms.oce.datasource.common.ImmutableAlarm;
+import org.opennms.oce.datasource.common.ImmutableAlarmFeedback;
 import org.opennms.oce.datasource.common.ImmutableSituation;
+
+import com.google.common.base.Enums;
 
 public class Mappers {
     public static final String SITUATION_UEI = "uei.opennms.org/alarms/situation";
@@ -143,5 +148,17 @@ public class Mappers {
         // TODO: Derive the inventory
         return Collections.emptyList();
 
+    }
+
+    public static AlarmFeedback toAlarmFeedback(org.opennms.integration.api.v1.model.AlarmFeedback alarmFeedback) {
+        return ImmutableAlarmFeedback.newBuilder()
+                .setSituationKey(alarmFeedback.getSituationKey())
+                .setSituationFingerprint(alarmFeedback.getSituationFingerprint())
+                .setAlarmKey(alarmFeedback.getAlarmKey())
+                .setReason(alarmFeedback.getReason())
+                .setFeedbackType(Enums.getIfPresent(FeedbackType.class, alarmFeedback.getFeedbackType().toString()).get())
+                .setUser(alarmFeedback.getUser())
+                .setTimestamp(alarmFeedback.getTimestamp())
+                .build();
     }
 }

--- a/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,6 +17,7 @@
         <argument ref="alarmFeedbackDao"/>
     </bean>
     <service ref="directAlarmFeedbackDatasource" interface="org.opennms.integration.api.v1.feedback.AlarmFeedbackListener"/>
+    <service ref="directAlarmFeedbackDatasource" interface="org.opennms.oce.datasource.api.AlarmFeedbackDatasource"/>
 
     <bean id="directInventoryDatasource" class="org.opennms.oce.datasource.opennms.jvm.DirectInventoryDatasource" init-method="init" >
         <argument ref="nodeDao"/>

--- a/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,5 +1,6 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
     <reference id="alarmDao" interface="org.opennms.integration.api.v1.dao.AlarmDao" />
+    <reference id="alarmFeedbackDao" interface="org.opennms.integration.api.v1.dao.AlarmFeedbackDao" />
     <reference id="nodeDao" interface="org.opennms.integration.api.v1.dao.NodeDao" />
     <reference id="eventForwarder" interface="org.opennms.integration.api.v1.events.EventForwarder" />
 
@@ -10,6 +11,12 @@
     <service ref="directAlarmDatasource" interface="org.opennms.oce.datasource.api.AlarmDatasource"/>
     <service ref="directAlarmDatasource" interface="org.opennms.oce.datasource.api.SituationDatasource"/>
     <service ref="directAlarmDatasource" interface="org.opennms.integration.api.v1.alarms.AlarmLifecycleListener"/>
+
+    <bean id="directAlarmFeedbackDatasource"
+          class="org.opennms.oce.datasource.opennms.jvm.DirectAlarmFeedbackDatasource" init-method="init">
+        <argument ref="alarmFeedbackDao"/>
+    </bean>
+    <service ref="directAlarmFeedbackDatasource" interface="org.opennms.integration.api.v1.feedback.AlarmFeedbackListener"/>
 
     <bean id="directInventoryDatasource" class="org.opennms.oce.datasource.opennms.jvm.DirectInventoryDatasource" init-method="init" >
         <argument ref="nodeDao"/>

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -13,6 +13,11 @@
         <feature dependency="true">aries-blueprint</feature>
     </feature>
 
+    <feature name="oce-datasource-common" description="OCE :: Datasource :: Common" version="${project.version}">
+        <bundle>mvn:org.opennms.oce.datasource/org.opennms.oce.datasource.opennms-common/${project.version}</bundle>
+        <bundle dependency="true">wrap:mvn:com.google.code.gson/gson/${gson.version}</bundle>
+    </feature>
+
     <feature name="oce-datasource-jaxb" description="OCE :: Datasource :: JAXB" version="${project.version}">
         <feature version="${project.version}">oce-datasource-api</feature>
         <bundle>mvn:org.opennms.oce.datasource/org.opennms.oce.datasource.jaxb/${project.version}</bundle>
@@ -33,12 +38,14 @@
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${okhttp.bundle.version}</bundle>
         <bundle dependency="true">wrap:mvn:com.squareup.okhttp3/logging-interceptor/${okhttp.version}</bundle>
         <bundle dependency="true">wrap:mvn:com.google.code.gson/gson/${gson.version}</bundle>
+        <feature dependency="true" version="${project.version}">oce-datasource-common</feature>
     </feature>
 
     <feature name="oce-datasource-opennms-direct" description="OCE :: Datasource :: OpenNMS Direct" version="${project.version}">
         <feature dependency="true">aries-blueprint</feature>
         <feature version="${opennms.api.version}" dependency="true">opennms-integration-api</feature>
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+        <feature dependency="true" version="${project.version}">oce-datasource-common</feature>
         <!-- Automatically install the standalone processor when using the direct datasource -->
         <feature version="${project.version}">oce-processor-standalone</feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <okhttp.version>3.10.0</okhttp.version>
         <okio.bundle.version>1.14.0_1</okio.bundle.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
-        <opennms.api.version>1.0.0-alpha1-SNAPSHOT</opennms.api.version>
+        <opennms.api.version>1.0.0-alpha3-SNAPSHOT</opennms.api.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <protobuf.version>3.5.1</protobuf.version>


### PR DESCRIPTION
This PR adds support for consuming alarm feedback from a direct data source without Kafka.