### PR TITLE
OCE-37: Build a map from two different OCE Datasets

### DIFF
--- a/datasource/jaxb/src/main/resources/model.v1.xsd
+++ b/datasource/jaxb/src/main/resources/model.v1.xsd
@@ -226,35 +226,35 @@
         </complexType>
     </element>
 
-    <element name="dataSetMap">
+    <element name="data-set-map">
         <annotation>
             <documentation>Top-level element for the container of mappings between data sets</documentation>
         </annotation>
 
         <complexType>
             <sequence>
-                <element ref="this:eventMap" minOccurs="0" maxOccurs="1"/>
-                <element ref="this:alarmMap" minOccurs="0" maxOccurs="1"/>
-                <element ref="this:situationMap" minOccurs="0" maxOccurs="1"/>
-                <element ref="this:inventoryMap" minOccurs="0" maxOccurs="1"/>
+                <element ref="this:event-map" minOccurs="0" maxOccurs="1"/>
+                <element ref="this:alarm-map" minOccurs="0" maxOccurs="1"/>
+                <element ref="this:situation-map" minOccurs="0" maxOccurs="1"/>
+                <element ref="this:inventory-map" minOccurs="0" maxOccurs="1"/>
             </sequence>
-            <attribute name="dataSetA" type="string" use="required"/>
-            <attribute name="dataSetB" type="string" use="required"/>
+            <attribute name="data-set-a" type="string" use="required"/>
+            <attribute name="data-set-b" type="string" use="required"/>
         </complexType>
     </element>
 
-    <element name="aToBMapping">
+    <element name="a-to-b-mapping">
         <annotation>
             <documentation>Definition for an instance of a mapping between an Id in data set A and an Id in data set B
             </documentation>
         </annotation>
         <complexType>
-            <attribute name="aId" type="string" use="required"/>
-            <attribute name="bId" type="string" use="required"/>
+            <attribute name="a-id" type="string" use="required"/>
+            <attribute name="b-id" type="string" use="required"/>
         </complexType>
     </element>
 
-    <element name="eventMap">
+    <element name="event-map">
         <annotation>
             <documentation>Top-level element for a list of event mappings</documentation>
         </annotation>
@@ -262,12 +262,12 @@
         <complexType>
             <sequence>
                 <!-- Event mapping definition -->
-                <element ref="this:aToBMapping" minOccurs="1" maxOccurs="unbounded"/>
+                <element ref="this:a-to-b-mapping" minOccurs="1" maxOccurs="unbounded"/>
             </sequence>
         </complexType>
     </element>
 
-    <element name="alarmMap">
+    <element name="alarm-map">
         <annotation>
             <documentation>Top-level element for a list of alarm mappings</documentation>
         </annotation>
@@ -275,12 +275,12 @@
         <complexType>
             <sequence>
                 <!-- Alarm mapping definition -->
-                <element ref="this:aToBMapping" minOccurs="1" maxOccurs="unbounded"/>
+                <element ref="this:a-to-b-mapping" minOccurs="1" maxOccurs="unbounded"/>
             </sequence>
         </complexType>
     </element>
 
-    <element name="situationMap">
+    <element name="situation-map">
         <annotation>
             <documentation>Top-level element for a list of situation mappings</documentation>
         </annotation>
@@ -288,12 +288,12 @@
         <complexType>
             <sequence>
                 <!-- Situation mapping definition -->
-                <element ref="this:aToBMapping" minOccurs="1" maxOccurs="unbounded"/>
+                <element ref="this:a-to-b-mapping" minOccurs="1" maxOccurs="unbounded"/>
             </sequence>
         </complexType>
     </element>
 
-    <element name="inventoryMap">
+    <element name="inventory-map">
         <annotation>
             <documentation>Top-level element for a list of inventory mappings</documentation>
         </annotation>
@@ -301,20 +301,20 @@
         <complexType>
             <sequence>
                 <!-- Inventory mapping definition -->
-                <element ref="this:aToBInventoryMapping" minOccurs="1" maxOccurs="unbounded"/>
+                <element ref="this:a-to-b-inventory-mapping" minOccurs="1" maxOccurs="unbounded"/>
             </sequence>
         </complexType>
     </element>
 
-    <element name="aToBInventoryMapping">
+    <element name="a-to-b-inventory-mapping">
         <annotation>
             <documentation>Definition for an instance of an inventory mapping</documentation>
         </annotation>
         <complexType>
-            <attribute name="aType" type="string" use="required"/>
-            <attribute name="aId" type="string" use="required"/>
-            <attribute name="bType" type="string" use="required"/>
-            <attribute name="bId" type="string" use="required"/>
+            <attribute name="a-type" type="string" use="required"/>
+            <attribute name="a-id" type="string" use="required"/>
+            <attribute name="b-type" type="string" use="required"/>
+            <attribute name="b-id" type="string" use="required"/>
         </complexType>
     </element>
 

--- a/datasource/jaxb/src/main/resources/model.v1.xsd
+++ b/datasource/jaxb/src/main/resources/model.v1.xsd
@@ -226,4 +226,96 @@
         </complexType>
     </element>
 
+    <element name="dataSetMap">
+        <annotation>
+            <documentation>Top-level element for the container of mappings between data sets</documentation>
+        </annotation>
+
+        <complexType>
+            <sequence>
+                <element ref="this:eventMap" minOccurs="0" maxOccurs="1"/>
+                <element ref="this:alarmMap" minOccurs="0" maxOccurs="1"/>
+                <element ref="this:situationMap" minOccurs="0" maxOccurs="1"/>
+                <element ref="this:inventoryMap" minOccurs="0" maxOccurs="1"/>
+            </sequence>
+            <attribute name="dataSetA" type="string" use="required"/>
+            <attribute name="dataSetB" type="string" use="required"/>
+        </complexType>
+    </element>
+
+    <element name="aToBMapping">
+        <annotation>
+            <documentation>Definition for an instance of a mapping between an Id in data set A and an Id in data set B
+            </documentation>
+        </annotation>
+        <complexType>
+            <attribute name="aId" type="string" use="required"/>
+            <attribute name="bId" type="string" use="required"/>
+        </complexType>
+    </element>
+
+    <element name="eventMap">
+        <annotation>
+            <documentation>Top-level element for a list of event mappings</documentation>
+        </annotation>
+
+        <complexType>
+            <sequence>
+                <!-- Event mapping definition -->
+                <element ref="this:aToBMapping" minOccurs="1" maxOccurs="unbounded"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="alarmMap">
+        <annotation>
+            <documentation>Top-level element for a list of alarm mappings</documentation>
+        </annotation>
+
+        <complexType>
+            <sequence>
+                <!-- Alarm mapping definition -->
+                <element ref="this:aToBMapping" minOccurs="1" maxOccurs="unbounded"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="situationMap">
+        <annotation>
+            <documentation>Top-level element for a list of situation mappings</documentation>
+        </annotation>
+
+        <complexType>
+            <sequence>
+                <!-- Situation mapping definition -->
+                <element ref="this:aToBMapping" minOccurs="1" maxOccurs="unbounded"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="inventoryMap">
+        <annotation>
+            <documentation>Top-level element for a list of inventory mappings</documentation>
+        </annotation>
+
+        <complexType>
+            <sequence>
+                <!-- Inventory mapping definition -->
+                <element ref="this:aToBInventoryMapping" minOccurs="1" maxOccurs="unbounded"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="aToBInventoryMapping">
+        <annotation>
+            <documentation>Definition for an instance of an inventory mapping</documentation>
+        </annotation>
+        <complexType>
+            <attribute name="aType" type="string" use="required"/>
+            <attribute name="aId" type="string" use="required"/>
+            <attribute name="bType" type="string" use="required"/>
+            <attribute name="bId" type="string" use="required"/>
+        </complexType>
+    </element>
+
 </schema>


### PR DESCRIPTION
- XML schema changes needed to map events/alarms/situations/inventory

Example output:
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<dataSetMap xmlns="http://xmlns.opennms.org/xsd/oce/model/v1.0.0" dataSetA="/test/from/cpn" dataSetB="/test/from/onms">
    <eventMap>
        <aToBMapping aId="aId" bId="bId"/>
    </eventMap>
    <alarmMap>
        <aToBMapping aId="aId" bId="bId"/>
    </alarmMap>
    <situationMap>
        <aToBMapping aId="aId" bId="bId"/>
    </situationMap>
    <inventoryMap>
        <aToBInventoryMapping aType="DEVICE" aId="aId" bType="DEVICE" bId="bId"/>
    </inventoryMap>
</dataSetMap
```