### PR TITLE
OCE-45: Prevent the opennms kafka datasource from blocking the initialization of the engine forever

### DIFF
--- a/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/OpennmsDatasource.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/OpennmsDatasource.java
@@ -117,6 +117,7 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
 
     public static final long DEFAULT_INVENTORY_GC_INTERVAL_MS = TimeUnit.MINUTES.toMillis(5);
     public static final long DEFAULT_INVENTORY_TTL_MS = TimeUnit.DAYS.toMillis(1);
+    public static final long DEFAULT_KAFKA_STORE_INIT_MS = TimeUnit.MILLISECONDS.convert(20, TimeUnit.SECONDS);
 
     private static final String INVENTORY_STORE_NODE_PREFIX = "node:";
     private static final String INVENTORY_STORE_ALARM_PREFIX = "alarm:";
@@ -146,6 +147,7 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
 
     private long inventoryGcIntervalMs = DEFAULT_INVENTORY_GC_INTERVAL_MS;
     private long inventoryTtlMs = DEFAULT_INVENTORY_TTL_MS;
+    private long kafkaStoreInitMs = DEFAULT_KAFKA_STORE_INIT_MS;
 
     private KafkaProducer<String, String> producer;
     private boolean alreadyWaitedForStores;
@@ -544,7 +546,7 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
 
         Stopwatch stopwatch = Stopwatch.createStarted();
 
-        while (stopwatch.elapsed(TimeUnit.SECONDS) <= 20) {
+        while (stopwatch.elapsed(TimeUnit.MILLISECONDS) <= getKafkaStoreInitMs()) {
             try {
                 ReadOnlyKeyValueStore<K, V> store = streams.store(storeName, QueryableStoreTypes.keyValueStore());
                 LOG.debug("Store {} is queryable", storeName);
@@ -649,6 +651,14 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
 
     public void setInventoryTtlMs(long inventoryTtlMs) {
         this.inventoryTtlMs = inventoryTtlMs;
+    }
+
+    public long getKafkaStoreInitMs() {
+        return kafkaStoreInitMs;
+    }
+
+    public void setKafkaStoreInitMs(long kafkaStoreInitMs) {
+        this.kafkaStoreInitMs = kafkaStoreInitMs;
     }
 
     @Override

--- a/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/OpennmsDatasource.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/OpennmsDatasource.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -39,7 +40,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -94,6 +98,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Stopwatch;
+
 public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, InventoryDatasource,
         AlarmFeedbackDatasource {
     private static final Logger LOG = LoggerFactory.getLogger(OpennmsDatasource.class);
@@ -142,6 +148,7 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
     private long inventoryTtlMs = DEFAULT_INVENTORY_TTL_MS;
 
     private KafkaProducer<String, String> producer;
+    private boolean alreadyWaitedForStores;
 
     public OpennmsDatasource(ConfigurationAdmin configAdmin) {
         this.configAdmin = Objects.requireNonNull(configAdmin);
@@ -376,7 +383,10 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
                 alarms.add(OpennmsMapper.toAlarm(entry.value));
             });
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            LOG.info("{}, returning empty list", e.getMessage());
         }
         return alarms;
     }
@@ -406,7 +416,10 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
                     alarmFeedback.addAll(OpennmsMapper.toAlarmFeedbackList(entry.value))
             );
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            LOG.info("{}, returning empty list", e.getMessage());
         }
         return alarmFeedback;
     }
@@ -446,7 +459,10 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
                 inventory.add(entry.value);
             });
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            LOG.info("{}, returning empty list", e.getMessage());
         }
 
         Set<ResourceKey> uniqueIds = new HashSet<>();
@@ -492,38 +508,60 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
                 situations.add(OpennmsMapper.toSituation(entry.value));
             });
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            LOG.info("{}, returning empty list", e.getMessage());
         }
         return situations;
     }
 
-    private ReadOnlyKeyValueStore<String, OpennmsModelProtos.Alarm> waitUntilSituationStoreIsQueryable() throws InterruptedException {
+    private ReadOnlyKeyValueStore<String, OpennmsModelProtos.Alarm> waitUntilSituationStoreIsQueryable()
+            throws InterruptedException, TimeoutException {
         return waitUntilStoreIsQueryable(SITUATION_STORE);
     }
 
-    private ReadOnlyKeyValueStore<String, OpennmsModelProtos.Alarm> waitUntilAlarmStoreIsQueryable() throws InterruptedException {
+    private ReadOnlyKeyValueStore<String, OpennmsModelProtos.Alarm> waitUntilAlarmStoreIsQueryable()
+            throws InterruptedException, TimeoutException {
         return waitUntilStoreIsQueryable(ALARM_STORE);
     }
 
-    private ReadOnlyKeyValueStore<String, InventoryModelProtos.InventoryObjects> waitUntilInventoryStoreIsQueryable() throws InterruptedException {
+    private ReadOnlyKeyValueStore<String, InventoryModelProtos.InventoryObjects> waitUntilInventoryStoreIsQueryable()
+            throws InterruptedException, TimeoutException {
         return waitUntilStoreIsQueryable(INVENTORY_STORE);
     }
 
-    private ReadOnlyKeyValueStore<String, FeedbackModelProtos.AlarmFeedbacks> waitUntilAlarmFeedbackStoreIsQueryable() throws InterruptedException {
+    private ReadOnlyKeyValueStore<String, FeedbackModelProtos.AlarmFeedbacks> waitUntilAlarmFeedbackStoreIsQueryable()
+            throws InterruptedException, TimeoutException {
         return waitUntilStoreIsQueryable(ALARM_FEEDBACK_STORE);
     }
 
-    private <K,V> ReadOnlyKeyValueStore<K, V> waitUntilStoreIsQueryable(String storeName) throws InterruptedException {
+    private <K, V> ReadOnlyKeyValueStore<K, V> waitUntilStoreIsQueryable(String storeName)
+            throws InterruptedException, TimeoutException {
         if (streams == null) {
             throw new IllegalStateException("Datasource must be started first.");
         }
-        while (true) {
+
+        Stopwatch stopwatch = Stopwatch.createStarted();
+
+        while (stopwatch.elapsed(TimeUnit.SECONDS) <= 20) {
             try {
-                return streams.store(storeName, QueryableStoreTypes.keyValueStore());
+                ReadOnlyKeyValueStore<K, V> store = streams.store(storeName, QueryableStoreTypes.keyValueStore());
+                LOG.debug("Store {} is queryable", storeName);
+                return store;
             } catch (InvalidStateStoreException ignored) {
+                // If we already waited for all the stores to be ready and they were or they timed out then we should
+                // not bother waiting again. The effect of this is that after waiting the first time, any subsequent
+                // attempts to wait will immediately time out if the store is not available on the first try.
+                if (alreadyWaitedForStores) {
+                    break;
+                }
                 Thread.sleep(100);
             }
         }
+
+        stopwatch.stop();
+        throw new TimeoutException(String.format("Timed out while waiting for store %s", storeName));
     }
 
     @Override
@@ -615,15 +653,61 @@ public class OpennmsDatasource implements SituationDatasource, AlarmDatasource, 
 
     @Override
     public void waitUntilReady() throws InterruptedException {
-        // These will block until Kafka is available and the topics are created
-        LOG.debug("Waiting for inventory store...");
-        waitUntilInventoryStoreIsQueryable();
-        LOG.debug("Waiting for alarm store...");
-        waitUntilAlarmStoreIsQueryable();
-        LOG.debug("Waiting for situation store...");
-        waitUntilSituationStoreIsQueryable();
-        LOG.debug("Waiting for alarm feedback store...");
-        waitUntilAlarmFeedbackStoreIsQueryable();
-        LOG.debug("All stores are available");
+        if (alreadyWaitedForStores) {
+            LOG.debug("Already waited for stores, not waiting again");
+            return;
+        }
+
+        // Create a collection of tasks that will wait for each of the data stores that this datasource depends on. We
+        // will then execute these wait tasks in parallel and join when the waiting is done.
+        Collection<Callable<Void>> waitForStoresTasks = new ArrayList<>();
+
+        // Wait for the inventory store
+        waitForStoresTasks.add(() -> {
+            LOG.debug("Waiting for inventory store...");
+            try {
+                waitUntilInventoryStoreIsQueryable();
+            } catch (TimeoutException e) {
+                LOG.info(e.getMessage());
+            }
+            return null;
+        });
+
+        // Wait for the alarm store
+        waitForStoresTasks.add(() -> {
+            LOG.debug("Waiting for alarm store...");
+            try {
+                waitUntilAlarmStoreIsQueryable();
+            } catch (TimeoutException e) {
+                LOG.info(e.getMessage());
+            }
+            return null;
+        });
+
+        // Wait for the situation store
+        waitForStoresTasks.add(() -> {
+            LOG.debug("Waiting for situation store...");
+            try {
+                waitUntilSituationStoreIsQueryable();
+            } catch (TimeoutException e) {
+                LOG.info(e.getMessage());
+            }
+            return null;
+        });
+
+        // Wait for the alarm feedback store
+        waitForStoresTasks.add(() -> {
+            LOG.debug("Waiting for alarm feedback store...");
+            try {
+                waitUntilAlarmFeedbackStoreIsQueryable();
+            } catch (TimeoutException e) {
+                LOG.info(e.getMessage());
+            }
+            return null;
+        });
+
+        Executors.newFixedThreadPool(waitForStoresTasks.size()).invokeAll(waitForStoresTasks);
+        LOG.debug("Done waiting for stores");
+        alreadyWaitedForStores = true;
     }
 }

--- a/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,6 +13,7 @@
             <cm:property name="edgesTopic" value="edges"/>
             <cm:property name="inventoryTtlMs" value="86400000"/> <!-- 24 hours -->
             <cm:property name="inventoryGcIntervalMs" value="300000"/> <!-- 5 minutes -->
+            <cm:property name="kafkaStoreInitMs" value="20000"/> <!-- 20 seconds -->
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -26,6 +27,7 @@
         <property name="inventoryTopic" value="${inventoryTopic}"/>
         <property name="inventoryTtlMs" value="${inventoryTtlMs}"/>
         <property name="inventoryGcIntervalMs" value="${inventoryGcIntervalMs}"/>
+        <property name="kafkaStoreInitMs" value="${kafkaStoreInitMs}"/>
     </bean>
     <service ref="opennmsDatasource" interface="org.opennms.oce.datasource.api.AlarmDatasource"/>
     <service ref="opennmsDatasource" interface="org.opennms.oce.datasource.api.AlarmFeedbackDatasource"/>


### PR DESCRIPTION
This PR improves the startup functionality when using the opennms kafka datasource. The previous behaviour caused it to block forever if any of the kafka stores were not available (alarms, inventory, situations, feedback).

Since it is quite likely that on startup one or more of these stores will not be present (especially when testing) we should instead wait some reasonable period of time (in this case 20 seconds) and then allow the engine to init.

The current behaviour made it difficult to test the topology edge consumption. It was also blocking the end to end tests causing them to fail (https://issues.opennms.org/browse/OCE-46).

This PR is currently target on top of OCE-40 but should be re-targeted to release when OCE-40 is merged.

Jira: https://issues.opennms.org/browse/OCE-45