### PR TITLE
Fix class name for redundancy factory so that the redundant code can be properly started

### DIFF
--- a/processor/redundant/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/processor/redundant/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -2,7 +2,7 @@
     <reference id="situationDataSource"
                interface="org.opennms.oce.datasource.api.SituationDatasource"/>
     <reference id="domainManagerFactory"
-               interface="org.opennms.features.distributed.coordination.api.DomainManagerFactory"/>
+               interface="org.opennms.integration.api.v1.coordination.DomainManagerFactory"/>
     <bean id="activeStandbySituationProcessor"
           class="org.opennms.oce.processor.redundant.ActiveStandbySituationProcessorFactory" destroy-method="destroy">
         <argument ref="situationDataSource"/>


### PR DESCRIPTION
Fixed a class name that was preventing the redundant processor code from working. This will cause failures in the e2e tests until fixed.

Related to Jira: https://issues.opennms.org/browse/OCE-46