### PR TITLE
OCE-47: Create a CI/CD pipeline to publish docs and artefacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
             tags:
               only: /.*/
 
-      # Run deploy jobs just on version tags and ignore branches
+      # Run deploy jobs just on version tags and master branch
       - deploy-maven:
           requires:
             - build
@@ -48,7 +48,8 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only:
+                - master
       - deploy-packages:
           requires:
             - build
@@ -56,7 +57,8 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only:
+                - master
       - deploy-docs:
           requires:
             - build-docs
@@ -64,7 +66,8 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only:
+                - master
 
 jobs:
   pre-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ workflows:
             branches:
               only:
                 - master
+                - /.*OCE-47/
       - deploy-packages:
           requires:
             - build
@@ -59,6 +60,7 @@ workflows:
             branches:
               only:
                 - master
+                - /.*OCE-47/
       - deploy-docs:
           requires:
             - build-docs
@@ -68,6 +70,7 @@ workflows:
             branches:
               only:
                 - master
+                - /.*OCE-47/
 
 jobs:
   pre-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,44 +1,63 @@
-version: 2
-defaults: &defaults
-  working_directory: /home/circleci/oce
-jobs:
-  build:
-    <<: *defaults
+version: 2.1
+
+executors:
+  build-executor:
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: opennms/build-env:1.0-b4
+        environment:
+          MAVEN_OPTS: -Xmx2g
 
-    environment:
-      MAVEN_OPTS: -Xmx2g
+  docs-executor:
+    docker:
+      - image: antora/antora:2.0.0
 
+  netlify-cli-executor:
+    docker:
+      - image: opennms/netlify-cli:2.8.3-b1
+
+  package-cloud-cli-executor:
+    docker:
+      - image: opennms/package-cloud-cli:0.3.05-b1
+
+workflows:
+  build-deploy:
+    jobs:
+      - pre-build
+      - build:
+          requires:
+            - pre-build
+      - build-docs:
+          requires:
+            - pre-build
+      - deploy-maven:
+          requires:
+            - build
+      - deploy-packages:
+          requires:
+            - build
+      - deploy-docs:
+          requires:
+            - build-docs
+
+jobs:
+  pre-build:
+    executor: build-executor
     steps:
-      - run:
-          name: Install RPM
-          command: sudo apt-get update; sudo apt-get install rpm
-
-      # Restore source cache
-      - restore_cache:
-          keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
-
       - checkout
 
-      # Save source cache
-      - save_cache:
-          key: source-v1-{{ .Branch }}-{{ .Revision }}
+      - persist_to_workspace:
+          root: ~/
           paths:
-            - ".git"
+            - project
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v2-dependencies-{{ checksum "pom.xml" }}
-          # fallback to using the latest cache if no exact match is found
-          - v2-dependencies-
+  build:
+    executor: build-executor
+    steps:
+      - attach_workspace:
+          at: ~/
 
       - run: |
-           mvn -DskipTests clean install dependency:resolve-plugins dependency:go-offline
+          mvn -DskipTests clean install dependency:resolve-plugins dependency:go-offline
 
       - save_cache:
           paths:
@@ -75,14 +94,31 @@ jobs:
           destination: dist
 
       - persist_to_workspace:
-          root: /home/circleci
+          root: ~/
           paths:
-            - oce
+            - project
+  
+  build-docs:
+    executor: docs-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Generate HTML output for documentation
+          command: |
+            antora generate site.yml
+
+      - store_artifacts:
+          path: build/site.zip
+          destination: site.zip
+
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project
 
   deploy-maven:
-    <<: *defaults
-    docker:
-      - image: circleci/openjdk:8-jdk-browsers
+    executor: build-executor
     steps:
       - attach_workspace:
           at: ~/
@@ -98,37 +134,22 @@ jobs:
             mvn -s .circleci.settings.xml -DskipTests deploy
 
   deploy-packages:
-    <<: *defaults
-    docker:
-      - image: circleci/jruby:9-jdk-browsers
+      executor: package-cloud-cli-executor
+      steps:
+        - attach_workspace:
+            at: ~/
+        - run:
+            name: Push RPM packages
+            command: |
+              package_cloud push opennms/plugin-snapshot/el/7 assembly/opennms-rpm/target/rpm/opennms-oce-plugin/RPMS/noarch/*
+              package_cloud push opennms/plugin-snapshot/el/7 assembly/sentinel-rpm/target/rpm/sentinel-oce-plugin/RPMS/noarch/*
+  
+  deploy-docs:
+    executor: netlify-cli-executor
     steps:
       - attach_workspace:
           at: ~/
       - run:
-          name: Install packagecloud CLI
-          command: gem install package_cloud
-      - run:
-          name: Push RPM packages
+          name: Deploy docs to Netlify
           command: |
-            package_cloud push opennms/plugin-snapshot/el/7 assembly/opennms-rpm/target/rpm/opennms-oce-plugin/RPMS/noarch/*
-            package_cloud push opennms/plugin-snapshot/el/7 assembly/sentinel-rpm/target/rpm/sentinel-oce-plugin/RPMS/noarch/*
-
-workflows:
-  version: 2
-  build-deploy:
-    jobs:
-      - build
-      - deploy-maven:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-               - master
-      - deploy-packages:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-               - master
+            netlify deploy --prod -d public -s ${NETLIFY_SITE_ID}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,22 +22,49 @@ executors:
 workflows:
   build-deploy:
     jobs:
-      - pre-build
+      # Run build jobs for all branches and any tag
+      - pre-build:
+          filters:
+            tags:
+              only: /.*/
       - build:
           requires:
             - pre-build
+          filters:
+            tags:
+              only: /.*/
       - build-docs:
           requires:
             - pre-build
+          filters:
+            tags:
+              only: /.*/
+
+      # Run deploy jobs just on version tags and ignore branches
       - deploy-maven:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - deploy-packages:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - deploy-docs:
           requires:
             - build-docs
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
 
 jobs:
   pre-build:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 tmp/
 target
 bin/
+public/
 
 # Editors
 .idea

--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ See the [installation guide](INSTALL.md) for details.
 
 See the [development guide](DEVEL.md) for details.
 
+## Release Checklist
+
+- [ ] Bump verison number from X.Y.Z-SNAPSHOT in `pom.xml` files
+- [ ] Bump version number from X.Y.Z-SNAPSHOT in `docs/antora.yml`
+- [ ] Create a version tag with a leading `v` in a format like `vX.Y.Z` in the master branch
+- [ ] Trigger release deployment with pushing the version tag to GitHub with `git push --tags`

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: oce
-version: 'master'
+version: '1.0.0-SNAPSHOT'
 title: OpenNMS Correlation Engine
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,0 +1,5 @@
+name: oce
+version: 'master'
+title: OpenNMS Correlation Engine
+nav:
+  - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,0 +1,2 @@
+.Installation
+* xref:install:preconditions.adoc[Preconditions]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,0 +1,5 @@
+= Welcome to our Documentation Site!
+:page-layout: home
+:!sectids:
+
+Welcome to the documentation site for the OpenNMS Correlation Engine (OCE).

--- a/docs/modules/install/pages/preconditions.adoc
+++ b/docs/modules/install/pages/preconditions.adoc
@@ -1,0 +1,3 @@
+= Preconditions
+
+This is what you need to install OCE.

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
       <repository>
         <id>sonatype.org-snapshot</id>
         <name>Sonatype OSS Snapshots Repository</name>
-	<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+	    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         <releases><enabled>false</enabled></releases>
         <snapshots><enabled>true</enabled></snapshots>
       </repository>

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,17 @@
+site: 
+  title: OpenNMS OCE Documentation
+  url: https://oce.opennms.eu
+  start_page: oce::index.adoc
+content: 
+  sources: 
+  - url: .
+    branches: master
+    start_path: docs
+ui:
+  bundle:
+    url: https://github.com/no42-org/antora-ui-opennms/releases/download/1.0/ui-bundle.zip
+output: 
+  clean: true 
+  dir: ./public 
+  destinations: 
+  - provider: archive 

--- a/site.yml
+++ b/site.yml
@@ -5,7 +5,7 @@ site:
 content: 
   sources: 
   - url: .
-    branches: master
+    branches: HEAD
     tags: v*
     start_path: docs
 ui:

--- a/site.yml
+++ b/site.yml
@@ -6,10 +6,11 @@ content:
   sources: 
   - url: .
     branches: master
+    tags: v*
     start_path: docs
 ui:
   bundle:
-    url: https://github.com/no42-org/antora-ui-opennms/releases/download/1.0/ui-bundle.zip
+    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.0.0/ui-bundle.zip
 output: 
   clean: true 
   dir: ./public 

--- a/test-api/.factorypath
+++ b/test-api/.factorypath
@@ -1,0 +1,6 @@
+<factorypath>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-slf4j-impl/2.8.2/log4j-slf4j-impl-2.8.2.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-api/2.8.2/log4j-api-2.8.2.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-core/2.8.2/log4j-core-2.8.2.jar" enabled="true" runInBatchMode="false"/>
+</factorypath>


### PR DESCRIPTION
Upgrade CircleCI to use 2.1 executor features and streamline the setup. Introduce executors for:

* Building with a build environment
* Using the published Antora 2.0.0 image to compile the docs
* Use a netlify-cli container image to publish docs to Netlify
* Use a package-cloud-cli image to publish to netlify

Introduced a pre-build step which checks out the source code which allows us to set global build specific tasks and we can run steps easier in parallel. It removes the dependency in later executor images to have git and SSH client installed.

Changes required outside of this PR in CircleCI:

* Add an environment variable NETLIFY_AUTH_TOKEN to deploy docs
* Add an environment variable NETLIFY_SITE_ID which defines the target where docs gets deployed
* Add an environment variable PACKAGECLOUD_TOKEN to publish the RPMS to package cloud


I haven't changed the targets for Maven deployment to oss.sonatype and I haven't changed the targets for RPM deployment. The jobs `deploy-maven` and `deploy-packages` will fail, cause I don't have the correct credentials in my CircleCI project to publish to these repositories.

I've set a filter, build runs on every branch and deploy runs only triggered by `git push --tags`.