### PR TITLE
OCE-49: Enable "Edit this page" functionality

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -4,7 +4,7 @@ site:
   start_page: oce::index.adoc
 content: 
   sources: 
-  - url: .
+  - url: https://github.com/OpenNMS/oce.git
     branches: HEAD
     tags: v*
     start_path: docs


### PR DESCRIPTION
By using the GitHub URL we can enable the "Edit this page" function. There is a downside, Antora itself checks out the GitHub repo and builds from there, but I think this is acceptable.

* JIRA: https://issues.opennms.org/browse/OCE-49