### PR TITLE
Revert "OCE-45: Prevent the opennms kafka datasource from blocking the initialization of the engine forever"

### DIFF
--- a/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,7 +13,6 @@
             <cm:property name="edgesTopic" value="edges"/>
             <cm:property name="inventoryTtlMs" value="86400000"/> <!-- 24 hours -->
             <cm:property name="inventoryGcIntervalMs" value="300000"/> <!-- 5 minutes -->
-            <cm:property name="kafkaStoreInitMs" value="20000"/> <!-- 20 seconds -->
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -27,7 +26,6 @@
         <property name="inventoryTopic" value="${inventoryTopic}"/>
         <property name="inventoryTtlMs" value="${inventoryTtlMs}"/>
         <property name="inventoryGcIntervalMs" value="${inventoryGcIntervalMs}"/>
-        <property name="kafkaStoreInitMs" value="${kafkaStoreInitMs}"/>
     </bean>
     <service ref="opennmsDatasource" interface="org.opennms.oce.datasource.api.AlarmDatasource"/>
     <service ref="opennmsDatasource" interface="org.opennms.oce.datasource.api.AlarmFeedbackDatasource"/>


### PR DESCRIPTION
Reverts OpenNMS/oce#55

We found that in practice these changes are likely to do more harm than good as they can make the init unstable if too short of a timeout is used. There was also a race condition resulting from these changes.

With these changes reverted, all the required topics must be created ahead of time.

I am verifying the revert via the end to end tests.