### PR TITLE
OCE-57: NPE in DirectInventoryDatasource

### DIFF
--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasource.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasource.java
@@ -38,8 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 import org.opennms.integration.api.v1.alarms.AlarmLifecycleListener;
@@ -98,11 +96,6 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
     private final CountDownLatch initLock = new CountDownLatch(1);
 
     /**
-     * A {@link ReadWriteLock} to synchronize the readers and writers of {@link #inventoryFromAlarms}.
-     */
-    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
-
-    /**
      * Used during {@link #init} to initialize {@link #inventoryFromNodes}.
      */
     private final NodeDao nodeDao;
@@ -126,7 +119,7 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
      * {@link AlarmDao}.
      */
     public void init() {
-        nodeDao.getNodes().forEach(n -> inventoryFromAlarms.addAll(Mappers.toInventory(n)));
+        nodeDao.getNodes().forEach(n -> inventoryFromNodes.addAll(Mappers.toInventory(n)));
         alarmDao.getAlarms().forEach(a -> processAlarm(a, false));
         initLock.countDown();
     }
@@ -151,22 +144,17 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
      * @param notifyHandlers   whether or not to notify handlers
      */
     private void addInventory(List<InventoryObject> inventoryObjects, boolean notifyHandlers) {
-        rwLock.writeLock().lock();
-        try {
-            // Only add and notify for inventory that was not already known
-            Set<InventoryObject> newInventory = Sets.difference(new HashSet<>(inventoryObjects),
-                    this.inventoryFromAlarms);
+        // Only add and notify for inventory that was not already known
+        Set<InventoryObject> newInventory = Sets.difference(new HashSet<>(inventoryObjects),
+                this.inventoryFromAlarms);
 
-            if (!newInventory.isEmpty()) {
-                if (notifyHandlers) {
-                    inventoryHandlers.forEach(handler -> handler.onInventoryAdded(newInventory));
-                }
+        if (!newInventory.isEmpty()) {
+            if (notifyHandlers) {
+                inventoryHandlers.forEach(handler -> handler.onInventoryAdded(newInventory));
             }
-
-            inventoryFromAlarms.addAll(newInventory);
-        } finally {
-            rwLock.writeLock().unlock();
         }
+
+        inventoryFromAlarms.addAll(newInventory);
     }
 
     /**
@@ -223,7 +211,7 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
     }
 
     @Override
-    public void handleAlarmSnapshot(List<Alarm> alarms) {
+    public synchronized void handleAlarmSnapshot(List<Alarm> alarms) {
         // Derive new inventory from the snapshot
         alarms.forEach(alarm -> processAlarm(alarm, true));
 
@@ -234,16 +222,16 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
     }
 
     @Override
-    public void handleNewOrUpdatedAlarm(Alarm alarm) {
+    public synchronized void handleNewOrUpdatedAlarm(Alarm alarm) {
         processAlarm(alarm, true);
     }
 
     @Override
-    public void handleDeletedAlarm(int alarmId, String reductionKey) {
+    public synchronized void handleDeletedAlarm(int alarmId, String reductionKey) {
         // Check if this alarm had any inventory associated
         Set<InventoryObject> inventoryForAlarm = alarmIdToInventoryMapping.get(alarmId);
 
-        if (inventoryForAlarm != null) {
+        if (inventoryForAlarm != null && !inventoryForAlarm.isEmpty()) {
             Set<InventoryObject> inventoryToRemove = new HashSet<>();
 
             inventoryForAlarm.forEach(inventory -> {
@@ -256,26 +244,25 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
                 }
             });
 
-            // Clean up the collections that contain this inventory
-            inventoryToRemove.forEach(inventory -> {
-                inventoryToAlarmIdMapping.remove(inventory);
-                inventoryFromAlarms.remove(inventory);
-            });
+            if (!inventoryToRemove.isEmpty()) {
+                // Clean up the collections that contain this inventory
+                inventoryToRemove.forEach(inventory -> {
+                    inventoryToAlarmIdMapping.remove(inventory);
+                    inventoryFromAlarms.remove(inventory);
+                });
 
-            inventoryHandlers.forEach(handler -> handler.onInventoryRemoved(inventoryToRemove));
+                inventoryHandlers.forEach(handler -> handler.onInventoryRemoved(inventoryToRemove));
+            }
+
+            // Since this alarm has been deleted we can clear the inventory associated with it
+            inventoryForAlarm.clear();
         }
     }
 
     @Override
-    public List<InventoryObject> getInventory() {
+    public synchronized List<InventoryObject> getInventory() {
         waitForInit();
-
-        rwLock.readLock().lock();
-        try {
-            return ImmutableList.copyOf(Sets.union(inventoryFromAlarms, inventoryFromNodes));
-        } finally {
-            rwLock.readLock().unlock();
-        }
+        return ImmutableList.copyOf(Sets.union(inventoryFromAlarms, inventoryFromNodes));
     }
 
     @Override

--- a/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
@@ -103,6 +103,11 @@ public class DirectInventoryDatasourceTest {
         // inventory
         dic.handleDeletedAlarm(alarm2.getId(), alarm2.getReductionKey());
         assertThat(inventory, hasSize(0));
+        
+        // A snapshot that would cause the alarms to be deleted should be handled without inventory changing
+        // since the alarms should already be deleted
+        dic.handleAlarmSnapshot(Collections.emptyList());
+        assertThat(inventory, hasSize(0));
 
         // A snapshot containing both alarms should result in the inventory being re-added
         dic.handleAlarmSnapshot(Arrays.asList(alarm1, alarm2));


### PR DESCRIPTION
Fixed an NPE that would be triggered if the same alarm was deleted more than once. You could cause this simply by sending a delete for the same alarm back to back. In practice I suspect this was caused by a delete coming in explicitly followed by a delete derived from a processing a snapshot.

I also simplified the thread-safety by synchronizing all the handle* methods as I think there is very little cost in doing so and it seems safer overall (I couldn't cause any threading issues by stress testing it, but better to be safer here I think).

The change to synchronization should effectively just mean that this code won't process a snapshot while it is in the middle of processing an add/delete. All of the add/delete should have already been coming in synchronously due to the behaviour of alarmd.

Jira: https://issues.opennms.org/browse/OCE-57

Reproduced with the small change to the unit tests. Then re-tested with the changes to verify the NPE no longer occurs.