### PR TITLE
OCE-46: Fix issue with circleci workflow deploying docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ workflows:
                 - master
       - deploy-docs:
           requires:
+            - build-docs
             - smoke-test
           filters:
             tags:
@@ -266,7 +267,8 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - project
+            - project/public
+            - project/build
 
   deploy-maven:
     executor: build-executor

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ java/bin/
 *.swo
 
 dependency-reduced-pom.xml
+
+# Ignore any copied KAR files produced for the smoke tests
+smoke-test/src/main/resources/sentinel-overlay/deploy/*.kar


### PR DESCRIPTION
- Fixed an issue where the circleci job was failing to deploy docs

The job needed to be dependent on the `build-docs` job and the `build-docs` job needed to be updated to only persist changes it made to the workspace, not persist the whole workspace again.

Since the job won't actually fire in this review branch, here is an example of the fix working in another test branch where I let the job run in all branches:
https://circleci.com/workflow-run/25d7505a-858a-4262-9b56-ee197ef83141

This is related to Jira: https://issues.opennms.org/browse/OCE-46