### PR TITLE
OCE-55: Add topology(link) support to the OpenNMS Direct datasource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,9 +109,9 @@ jobs:
 
       - restore_cache:
           keys:
-          - v4-dependencies-{{ checksum "pom.xml" }}
+          - v5-dependencies-{{ checksum "pom.xml" }}
           # fallback to using the latest cache if no exact match is found
-          - v4-dependencies-
+          - v5-dependencies-
 
       - run:
           name: Build
@@ -121,7 +121,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: v4-dependencies-{{ checksum "pom.xml" }}
+          key: v5-dependencies-{{ checksum "pom.xml" }}
 
       - run:
           name: Run the tests
@@ -177,9 +177,9 @@ jobs:
           # attempt to use the cache from the last smoke-test run
           - v2-smoke-dependencies-{{ checksum "smoke-test/pom.xml" }}-{{ checksum "pom.xml" }}
           # use the cache built for the same root pom
-          - v4-dependencies-{{ checksum "pom.xml" }}
+          - v5-dependencies-{{ checksum "pom.xml" }}
           # fallback to using the latest cache if no exact match is found
-          - v4-dependencies-
+          - v5-dependencies-
           
       - restore_cache:
           keys:
@@ -285,9 +285,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v4-dependencies-{{ checksum "pom.xml" }}
+          - v5-dependencies-{{ checksum "pom.xml" }}
           # fallback to using the latest cache if no exact match is found
-          - v4-dependencies-
+          - v5-dependencies-
 
       - run:
           name: Deploy the artifacts

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableAlarm.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableAlarm.java
@@ -33,6 +33,9 @@ import java.util.Objects;
 import org.opennms.oce.datasource.api.Alarm;
 import org.opennms.oce.datasource.api.Severity;
 
+/**
+ * An implementation of {@link Alarm} that enforces deep immutability.
+ */
 public final class ImmutableAlarm implements Alarm {
     private final String id;
     private final long time;
@@ -54,7 +57,7 @@ public final class ImmutableAlarm implements Alarm {
         this.nodeId = builder.nodeId;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String id;
         private long time;
         private Severity severity;

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableAlarmFeedback.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableAlarmFeedback.java
@@ -33,6 +33,9 @@ import java.util.Objects;
 import org.opennms.oce.datasource.api.AlarmFeedback;
 import org.opennms.oce.datasource.api.FeedbackType;
 
+/**
+ * An implementation of {@link AlarmFeedback} that enforces deep immutability.
+ */
 public final class ImmutableAlarmFeedback implements AlarmFeedback {
     private final String situationKey;
     private final String situationFingerprint;
@@ -52,7 +55,7 @@ public final class ImmutableAlarmFeedback implements AlarmFeedback {
         this.timestamp = builder.timestamp;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String situationKey;
         private String situationFingerprint;
         private String alarmKey;

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObject.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObject.java
@@ -93,8 +93,8 @@ public final class ImmutableInventoryObject implements InventoryObject {
             this.friendlyName = inventoryObject.getFriendlyName();
             this.isTopLevel = inventoryObject.isTopLevel();
             // Copy contents for the collections to avoid referencing a collection we don't control
-            this.peers.addAll(inventoryObject.getPeers());
-            this.relatives.addAll(inventoryObject.getRelatives());
+            this.peers = new ArrayList<>(inventoryObject.getPeers());
+            this.relatives = new ArrayList<>(inventoryObject.getRelatives());
             this.weightToParent = inventoryObject.getWeightToParent();
         }
 

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObject.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObject.java
@@ -38,6 +38,9 @@ import org.opennms.oce.datasource.api.InventoryObject;
 import org.opennms.oce.datasource.api.InventoryObjectPeerRef;
 import org.opennms.oce.datasource.api.InventoryObjectRelativeRef;
 
+/**
+ * An implementation of {@link InventoryObject} that enforces deep immutability.
+ */
 public final class ImmutableInventoryObject implements InventoryObject {
     private final String type;
     private final String id;
@@ -58,12 +61,14 @@ public final class ImmutableInventoryObject implements InventoryObject {
         this.subtype = builder.subtype;
         this.friendlyName = builder.friendlyName;
         this.isTopLevel = builder.isTopLevel;
-        this.peers = builder.peers == null ? null : copyPeers(builder.peers);
-        this.relatives = builder.relatives == null ? null : copyRelatives(builder.relatives);
+        this.peers = builder.peers == null ? Collections.emptyList() :
+                Collections.unmodifiableList(copyPeers(builder.peers));
+        this.relatives = builder.relatives == null ? Collections.emptyList() :
+                Collections.unmodifiableList(copyRelatives(builder.relatives));
         this.weightToParent = builder.weightToParent;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String type;
         private String id;
         private String parentType;
@@ -71,8 +76,8 @@ public final class ImmutableInventoryObject implements InventoryObject {
         private String subtype;
         private String friendlyName;
         private boolean isTopLevel;
-        private List<InventoryObjectPeerRef> peers = new ArrayList<>();
-        private List<InventoryObjectRelativeRef> relatives = new ArrayList<>();
+        private List<InventoryObjectPeerRef> peers;
+        private List<InventoryObjectRelativeRef> relatives;
         private long weightToParent;
 
         private Builder() {
@@ -134,7 +139,10 @@ public final class ImmutableInventoryObject implements InventoryObject {
         }
 
         public Builder addPeer(InventoryObjectPeerRef peer) {
-            this.peers.add(peer);
+            if (peers == null) {
+                peers = new ArrayList<>();
+            }
+            peers.add(peer);
             return this;
         }
 
@@ -144,7 +152,10 @@ public final class ImmutableInventoryObject implements InventoryObject {
         }
 
         public Builder addRelative(InventoryObjectRelativeRef relative) {
-            this.relatives.add(relative);
+            if (relatives == null) {
+                relatives = new ArrayList<>();
+            }
+            relatives.add(relative);
             return this;
         }
 
@@ -251,12 +262,12 @@ public final class ImmutableInventoryObject implements InventoryObject {
 
     @Override
     public List<InventoryObjectPeerRef> getPeers() {
-        return peers == null ? Collections.emptyList() : Collections.unmodifiableList(peers);
+        return peers;
     }
 
     @Override
     public List<InventoryObjectRelativeRef> getRelatives() {
-        return relatives == null ? Collections.emptyList() : Collections.unmodifiableList(relatives);
+        return relatives;
     }
 
     @Override

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObject.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObject.java
@@ -251,12 +251,12 @@ public final class ImmutableInventoryObject implements InventoryObject {
 
     @Override
     public List<InventoryObjectPeerRef> getPeers() {
-        return peers == null ? null : Collections.unmodifiableList(peers);
+        return peers == null ? Collections.emptyList() : Collections.unmodifiableList(peers);
     }
 
     @Override
     public List<InventoryObjectRelativeRef> getRelatives() {
-        return relatives == null ? null : Collections.unmodifiableList(relatives);
+        return relatives == null ? Collections.emptyList() : Collections.unmodifiableList(relatives);
     }
 
     @Override

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObjectPeerRef.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObjectPeerRef.java
@@ -35,6 +35,9 @@ import java.util.Objects;
 import org.opennms.oce.datasource.api.InventoryObjectPeerEndpoint;
 import org.opennms.oce.datasource.api.InventoryObjectPeerRef;
 
+/**
+ * An implementation of {@link InventoryObjectPeerRef} that enforces deep immutability.
+ */
 public final class ImmutableInventoryObjectPeerRef implements InventoryObjectPeerRef {
     private final String type;
     private final String id;
@@ -48,7 +51,7 @@ public final class ImmutableInventoryObjectPeerRef implements InventoryObjectPee
         this.weight = builder.weight;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String type;
         private String id;
         private InventoryObjectPeerEndpoint endpoint;

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObjectRelativeRef.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableInventoryObjectRelativeRef.java
@@ -34,6 +34,9 @@ import java.util.Objects;
 
 import org.opennms.oce.datasource.api.InventoryObjectRelativeRef;
 
+/**
+ * An implementation of {@link InventoryObjectRelativeRef} that enforces deep immutability.
+ */
 public final class ImmutableInventoryObjectRelativeRef implements InventoryObjectRelativeRef {
     private final String type;
     private final String id;
@@ -45,7 +48,7 @@ public final class ImmutableInventoryObjectRelativeRef implements InventoryObjec
         this.weight = builder.weight;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String type;
         private String id;
         private long weight;

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableSituation.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableSituation.java
@@ -84,11 +84,11 @@ public final class ImmutableSituation implements Situation {
             this.creationTime = situation.getCreationTime();
             this.severity = situation.getSeverity();
             // Copy contents for the collections to avoid referencing a collection we don't control
-            this.resourceKeys.addAll(situation.getResourceKeys());
-            this.alarms.putAll(situation.getAlarms()
+            this.resourceKeys = new ArrayList<>(situation.getResourceKeys());
+            this.alarms = situation.getAlarms()
                     .stream()
                     .collect(Collectors.toMap(Alarm::getId, alarm -> alarm,
-                            (Alarm oldAlarm, Alarm newAlarm) -> newAlarm, LinkedHashMap::new)));
+                            (Alarm oldAlarm, Alarm newAlarm) -> newAlarm, LinkedHashMap::new));
             this.diagnosticText = situation.getDiagnosticText();
         }
 
@@ -141,6 +141,9 @@ public final class ImmutableSituation implements Situation {
 
         public Builder addAlarm(Alarm alarm, BiPredicate<String, String> predicate) {
             if (predicate.test(alarm.getId(), id)) {
+                if (alarms == null) {
+                    alarms = new LinkedHashMap<>();
+                }
                 this.alarms.put(alarm.getId(), alarm);
             }
 

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableSituation.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableSituation.java
@@ -195,12 +195,12 @@ public final class ImmutableSituation implements Situation {
 
     @Override
     public List<ResourceKey> getResourceKeys() {
-        return resourceKeys == null ? null : Collections.unmodifiableList(resourceKeys);
+        return resourceKeys == null ? Collections.emptyList() : Collections.unmodifiableList(resourceKeys);
     }
 
     @Override
     public Set<Alarm> getAlarms() {
-        return alarms == null ? null : Collections.unmodifiableSet(new HashSet<>(alarms.values()));
+        return alarms == null ? Collections.emptySet() : Collections.unmodifiableSet(new HashSet<>(alarms.values()));
     }
 
     @Override

--- a/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableSituation.java
+++ b/datasource/common/src/main/java/org/opennms/oce/datasource/common/ImmutableSituation.java
@@ -44,29 +44,36 @@ import org.opennms.oce.datasource.api.ResourceKey;
 import org.opennms.oce.datasource.api.Severity;
 import org.opennms.oce.datasource.api.Situation;
 
+/**
+ * An implementation of {@link Situation} that enforces deep immutability.
+ */
 public final class ImmutableSituation implements Situation {
     private final String id;
     private final long creationTime;
     private final Severity severity;
     private final List<ResourceKey> resourceKeys;
     private final Map<String, Alarm> alarms;
+    private final Set<Alarm> alarmsFromMap;
     private final String diagnosticText;
 
     private ImmutableSituation(Builder builder) {
         this.id = builder.id;
         this.creationTime = builder.creationTime;
         this.severity = builder.severity;
-        this.resourceKeys = builder.resourceKeys == null ? null : new ArrayList<>(builder.resourceKeys);
-        this.alarms = builder.alarms == null ? null : copyAlarms(builder.alarms);
+        this.resourceKeys = builder.resourceKeys == null ? Collections.emptyList() :
+                Collections.unmodifiableList(new ArrayList<>(builder.resourceKeys));
+        this.alarms = builder.alarms == null ? Collections.emptyMap() :
+                Collections.unmodifiableMap(copyAlarms(builder.alarms));
+        this.alarmsFromMap = Collections.unmodifiableSet(new HashSet<>(alarms.values()));
         this.diagnosticText = builder.diagnosticText;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String id;
         private Long creationTime;
         private Severity severity;
-        private List<ResourceKey> resourceKeys = new ArrayList<>();
-        private Map<String, Alarm> alarms = new LinkedHashMap<>();
+        private List<ResourceKey> resourceKeys;
+        private Map<String, Alarm> alarms;
         private String diagnosticText;
 
         private Builder() {
@@ -106,6 +113,9 @@ public final class ImmutableSituation implements Situation {
         }
 
         public Builder addResourceKey(ResourceKey resourceKey) {
+            if (resourceKeys == null) {
+                resourceKeys = new ArrayList<>();
+            }
             resourceKeys.add(resourceKey);
             return this;
         }
@@ -122,7 +132,10 @@ public final class ImmutableSituation implements Situation {
         }
 
         public Builder addAlarm(Alarm alarm) {
-            this.alarms.put(alarm.getId(), alarm);
+            if (alarms == null) {
+                alarms = new LinkedHashMap<>();
+            }
+            alarms.put(alarm.getId(), alarm);
             return this;
         }
 
@@ -195,12 +208,12 @@ public final class ImmutableSituation implements Situation {
 
     @Override
     public List<ResourceKey> getResourceKeys() {
-        return resourceKeys == null ? Collections.emptyList() : Collections.unmodifiableList(resourceKeys);
+        return resourceKeys;
     }
 
     @Override
     public Set<Alarm> getAlarms() {
-        return alarms == null ? Collections.emptySet() : Collections.unmodifiableSet(new HashSet<>(alarms.values()));
+        return alarmsFromMap;
     }
 
     @Override

--- a/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Edge.java
+++ b/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Edge.java
@@ -34,43 +34,14 @@ import java.util.Objects;
  * Utility methods for deriving Edge attributes.
  */
 public class Edge {
-    /**
-     * @return the friendly name using a target port
-     */
-    public static String generateFriendlyName(long sourceIfIndex, String sourceNodeCriteria, long targetIfIndex,
-                                              String targetNodeCriteria, String protocol) {
-        return String.format("Link Between %d on %s and %d on %s discovered with " +
-                        "protocol %s", sourceIfIndex, Objects.requireNonNull(sourceNodeCriteria), targetIfIndex,
-                Objects.requireNonNull(targetNodeCriteria), Objects.requireNonNull(protocol));
+    public static String generateId(String protocol, String peerAId, String peerZId) {
+        return String.format("%s:%s:%s", Objects.requireNonNull(protocol), Objects.requireNonNull(peerAId),
+                Objects.requireNonNull(peerZId));
     }
 
-    /**
-     * @return the friendly name using a target segment
-     */
-    public static String generateFriendlyName(long sourceIfIndex, String sourceNodeCriteria,
-                                              String targetSegmentCriteria, String protocol) {
-        return String.format("Link Between %d on %s and segment %s discovered with protocol %s",
-                sourceIfIndex, Objects.requireNonNull(sourceNodeCriteria),
-                Objects.requireNonNull(targetSegmentCriteria), Objects.requireNonNull(protocol));
-    }
-
-    /**
-     * @return the Id using a target port
-     */
-    public static String generateId(long sourceIfIndex, String sourceNodeCriteria, long targetIfIndex,
-                                    String targetNodeCriteria, String protocol) {
-        return String.format("%s:%s:%d:%s:%d", Objects.requireNonNull(protocol),
-                Objects.requireNonNull(sourceNodeCriteria), sourceIfIndex, Objects.requireNonNull(targetNodeCriteria)
-                , targetIfIndex);
-    }
-
-    /**
-     * @return the Id using a target segment
-     */
-    public static String generateId(long sourceIfIndex, String sourceNodeCriteria, String targetSegmentCriteria,
-                                    String protocol) {
-        return String.format("%s:%s:%d:%s", Objects.requireNonNull(protocol),
-                Objects.requireNonNull(sourceNodeCriteria), sourceIfIndex,
-                Objects.requireNonNull(targetSegmentCriteria));
+    public static String generateFriendlyName(String protocol, String peerAId,
+                                              String peerZId) {
+        return String.format("Link Between %s and %s discovered with protocol %s", Objects.requireNonNull(peerAId),
+                Objects.requireNonNull(peerZId), Objects.requireNonNull(protocol));
     }
 }

--- a/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Edge.java
+++ b/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Edge.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.oce.datasource.common.inventory;
+
+import java.util.Objects;
+
+/**
+ * Utility methods for deriving Edge attributes.
+ */
+public class Edge {
+    /**
+     * @return the friendly name using a target port
+     */
+    public static String generateFriendlyName(long sourceIfIndex, String sourceNodeCriteria, long targetIfIndex,
+                                              String targetNodeCriteria, String protocol) {
+        return String.format("Link Between %d on %s and %d on %s discovered with " +
+                        "protocol %s", sourceIfIndex, Objects.requireNonNull(sourceNodeCriteria), targetIfIndex,
+                Objects.requireNonNull(targetNodeCriteria), Objects.requireNonNull(protocol));
+    }
+
+    /**
+     * @return the friendly name using a target segment
+     */
+    public static String generateFriendlyName(long sourceIfIndex, String sourceNodeCriteria,
+                                              String targetSegmentCriteria, String protocol) {
+        return String.format("Link Between %d on %s and segment %s discovered with protocol %s",
+                sourceIfIndex, Objects.requireNonNull(sourceNodeCriteria),
+                Objects.requireNonNull(targetSegmentCriteria), Objects.requireNonNull(protocol));
+    }
+
+    /**
+     * @return the Id using a target port
+     */
+    public static String generateId(long sourceIfIndex, String sourceNodeCriteria, long targetIfIndex,
+                                    String targetNodeCriteria, String protocol) {
+        return String.format("%s:%s:%d:%s:%d", Objects.requireNonNull(protocol),
+                Objects.requireNonNull(sourceNodeCriteria), sourceIfIndex, Objects.requireNonNull(targetNodeCriteria)
+                , targetIfIndex);
+    }
+
+    /**
+     * @return the Id using a target segment
+     */
+    public static String generateId(long sourceIfIndex, String sourceNodeCriteria, String targetSegmentCriteria,
+                                    String protocol) {
+        return String.format("%s:%s:%d:%s", Objects.requireNonNull(protocol),
+                Objects.requireNonNull(sourceNodeCriteria), sourceIfIndex,
+                Objects.requireNonNull(targetSegmentCriteria));
+    }
+}

--- a/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/ManagedObjectType.java
+++ b/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/ManagedObjectType.java
@@ -36,6 +36,9 @@ import java.util.Objects;
 public enum ManagedObjectType {
     Node("node"),
     SnmpInterface("snmp-interface"),
+    /**
+     * A link between two interfaces or an interface and a node.
+     */
     SnmpInterfaceLink("snmp-interface-link"),
     BgpPeer("bgp-peer"),
     VpnTunnel("vpn-tunnel"),
@@ -44,8 +47,18 @@ public enum ManagedObjectType {
     OspfRouter("ospf-router"),
     MplsTunnel("mpls-tunnel"),
     MplsLdpSession("mpls-ldp-session"),
-    Segment("segment"),
-    BridgeLink("bridge-link");
+    /**
+     * A L2 segment or a bridge device.
+     */
+    BridgeSegment("bridge-segment"),
+    /**
+     * A link between two bridges or a segment and a port.
+     */
+    BridgeLink("bridge-link"),
+    /**
+     * A link directly between two nodes.
+     */
+    NodeLink("node-link");
 
     private final String name;
 

--- a/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Port.java
+++ b/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Port.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,39 +28,13 @@
 
 package org.opennms.oce.datasource.common.inventory;
 
-
-import java.util.Arrays;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 
-public enum ManagedObjectType {
-    Node("node"),
-    SnmpInterface("snmp-interface"),
-    SnmpInterfaceLink("snmp-interface-link"),
-    BgpPeer("bgp-peer"),
-    VpnTunnel("vpn-tunnel"),
-    MplsL3Vrf("mpls-l3-vrf"),
-    EntPhysicalEntity("ent-physical-entity"),
-    OspfRouter("ospf-router"),
-    MplsTunnel("mpls-tunnel"),
-    MplsLdpSession("mpls-ldp-session"),
-    Segment("segment"),
-    BridgeLink("bridge-link");
-
-    private final String name;
-
-    ManagedObjectType(String name) {
-        this.name = Objects.requireNonNull(name);
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public static ManagedObjectType fromName(String name) {
-        return Arrays.stream(ManagedObjectType.values())
-                .filter(mot -> Objects.equals(name, mot.getName()))
-                .findFirst()
-                .orElseThrow(() -> new NoSuchElementException("No type found with name: " + name));
+/**
+ * Utility methods for deriving Port attributes.
+ */
+public class Port {
+    public static String generateId(long ifIndex, String nodeCriteria, String protocol) {
+        return String.format("%s:%s:%d", Objects.requireNonNull(protocol), Objects.requireNonNull(nodeCriteria), ifIndex);
     }
 }

--- a/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Port.java
+++ b/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Port.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  * Utility methods for deriving Port attributes.
  */
 public class Port {
-    public static String generateId(long ifIndex, String nodeCriteria, String protocol) {
-        return String.format("%s:%s:%d", Objects.requireNonNull(protocol), Objects.requireNonNull(nodeCriteria), ifIndex);
+    public static String generateId(long ifIndex, String nodeCriteria) {
+        return String.format("%s:%d", Objects.requireNonNull(nodeCriteria), ifIndex);
     }
 }

--- a/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Segment.java
+++ b/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/Segment.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,39 +28,13 @@
 
 package org.opennms.oce.datasource.common.inventory;
 
-
-import java.util.Arrays;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 
-public enum ManagedObjectType {
-    Node("node"),
-    SnmpInterface("snmp-interface"),
-    SnmpInterfaceLink("snmp-interface-link"),
-    BgpPeer("bgp-peer"),
-    VpnTunnel("vpn-tunnel"),
-    MplsL3Vrf("mpls-l3-vrf"),
-    EntPhysicalEntity("ent-physical-entity"),
-    OspfRouter("ospf-router"),
-    MplsTunnel("mpls-tunnel"),
-    MplsLdpSession("mpls-ldp-session"),
-    Segment("segment"),
-    BridgeLink("bridge-link");
-
-    private final String name;
-
-    ManagedObjectType(String name) {
-        this.name = Objects.requireNonNull(name);
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public static ManagedObjectType fromName(String name) {
-        return Arrays.stream(ManagedObjectType.values())
-                .filter(mot -> Objects.equals(name, mot.getName()))
-                .findFirst()
-                .orElseThrow(() -> new NoSuchElementException("No type found with name: " + name));
+/**
+ * Utility methods for deriving Segment attributes.
+ */
+public class Segment {
+    public static String generateId(String id, String protocol) {
+        return String.format("%s:%s", Objects.requireNonNull(protocol), Objects.requireNonNull(id));
     }
 }

--- a/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/script/AbstractScriptedInventory.java
+++ b/datasource/opennms-common/src/main/java/org/opennms/oce/datasource/common/inventory/script/AbstractScriptedInventory.java
@@ -55,6 +55,8 @@ public abstract class AbstractScriptedInventory {
 
     private static final String DEFAULT_SCRIPT = "/inventory.groovy";
 
+    protected static final String DEFAULT_SCRIPT_FULL_PATH = "src/main/resources/inventory.groovy";
+
     private static final String DEFAULT_SCRIPT_EXTENSION = "groovy";
 
     private final boolean usingClasspathScript;

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/ApiMapper.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/ApiMapper.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import org.opennms.integration.api.v1.model.EventParameter;
 import org.opennms.integration.api.v1.model.InMemoryEvent;
 import org.opennms.integration.api.v1.model.Node;
+import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.integration.api.v1.model.beans.InMemoryEventBean;
 import org.opennms.oce.datasource.api.Alarm;
 import org.opennms.oce.datasource.api.AlarmFeedback;
@@ -80,7 +81,7 @@ public class ApiMapper {
                 .setSummary(alarm.getLogMessage())
                 .setDescription(alarm.getDescription())
                 .setNodeId(alarm.getNode() != null ? alarm.getNode().getId().longValue() : null);
-            try {
+        try {
             inventoryService.overrideTypeAndInstance(alarmBuilder, alarm);
         } catch (ScriptedInventoryException e) {
             LOG.error("Failure overriding inventory for alarm [{}] : {}", alarm, e.getCause().getMessage());
@@ -163,7 +164,7 @@ public class ApiMapper {
         if (severity == null) {
             return null;
         }
-        switch(severity) {
+        switch (severity) {
             case CRITICAL:
                 return org.opennms.integration.api.v1.model.Severity.CRITICAL;
             case MAJOR:
@@ -184,7 +185,7 @@ public class ApiMapper {
         if (severity == null) {
             return null;
         }
-        switch(severity) {
+        switch (severity) {
             case CLEARED:
                 return Severity.CLEARED;
             case NORMAL:
@@ -231,5 +232,15 @@ public class ApiMapper {
                 .setUser(alarmFeedback.getUser())
                 .setTimestamp(alarmFeedback.getTimestamp())
                 .build();
+    }
+
+    public List<InventoryObject> toInventory(TopologyEdge edge) {
+        try {
+            return inventoryService.createInventoryObjects(edge);
+        } catch (ScriptedInventoryException e) {
+            LOG.error("Failed to retrieve inventory for edge {}, : {}", edge, e.getCause().getMessage());
+            LOG.error("Failed to retrieve inventory for edge", e);
+            return Collections.emptyList();
+        }
     }
 }

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasource.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasource.java
@@ -48,6 +48,7 @@ import org.opennms.integration.api.v1.dao.NodeDao;
 import org.opennms.integration.api.v1.model.Alarm;
 import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.topology.TopologyEdgeConsumer;
 import org.opennms.oce.datasource.api.InventoryDatasource;
 import org.opennms.oce.datasource.api.InventoryHandler;
@@ -132,29 +133,21 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
     private final EdgeDao edgeDao;
 
     /**
-     * A comma separated list of protocols that this datasource should consume. Effectively filters updates received
-     * from {@link #onEdgeAddedOrUpdated(TopologyEdge)} and {@link #onEdgeDeleted(TopologyEdge)}.
-     */
-    private final String topologyProtocols;
-
-    /**
      * A mapper for deriving inventory objects.
      */
     private final ApiMapper mapper;
 
     /**
-     * @param nodeDao           used to retrieve the current inventory
-     * @param alarmDao          used to retrieve the current inventory
-     * @param edgeDao           used to retrieve the current inventory
-     * @param topologyProtocols the protocols supported for topology updates
-     * @param mapper            used to Map between API and OCE types
+     * @param nodeDao  used to retrieve the current inventory
+     * @param alarmDao used to retrieve the current inventory
+     * @param edgeDao  used to retrieve the current inventory
+     * @param mapper   used to Map between API and OCE types
      */
     public DirectInventoryDatasource(NodeDao nodeDao, AlarmDao alarmDao, EdgeDao edgeDao, String topologyProtocols,
                                      ApiMapper mapper) {
         this.nodeDao = Objects.requireNonNull(nodeDao);
         this.alarmDao = Objects.requireNonNull(alarmDao);
         this.edgeDao = Objects.requireNonNull(edgeDao);
-        this.topologyProtocols = Objects.requireNonNull(topologyProtocols);
         this.mapper = Objects.requireNonNull(mapper);
     }
 
@@ -400,8 +393,8 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
     }
 
     @Override
-    public String getProtocols() {
-        return topologyProtocols;
+    public Set<TopologyProtocol> getProtocols() {
+        return Collections.singleton(TopologyProtocol.ALL);
     }
 
     @Override

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasource.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasource.java
@@ -143,8 +143,7 @@ public class DirectInventoryDatasource implements InventoryDatasource, AlarmLife
      * @param edgeDao  used to retrieve the current inventory
      * @param mapper   used to Map between API and OCE types
      */
-    public DirectInventoryDatasource(NodeDao nodeDao, AlarmDao alarmDao, EdgeDao edgeDao, String topologyProtocols,
-                                     ApiMapper mapper) {
+    public DirectInventoryDatasource(NodeDao nodeDao, AlarmDao alarmDao, EdgeDao edgeDao, ApiMapper mapper) {
         this.nodeDao = Objects.requireNonNull(nodeDao);
         this.alarmDao = Objects.requireNonNull(alarmDao);
         this.edgeDao = Objects.requireNonNull(edgeDao);

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/OpennmsDirectScriptedInventory.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/OpennmsDirectScriptedInventory.java
@@ -30,8 +30,6 @@ package org.opennms.oce.datasource.opennms.jvm;
 
 import java.util.List;
 
-import javax.script.ScriptException;
-
 import org.opennms.integration.api.v1.model.Alarm;
 import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.TopologyEdge;
@@ -47,20 +45,21 @@ import org.slf4j.LoggerFactory;
  * @author smith
  *
  */
-public class ScriptedInventoryImpl extends AbstractScriptedInventory implements ScriptedInventoryService {
+public class OpennmsDirectScriptedInventory extends AbstractScriptedInventory implements ScriptedInventoryService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ScriptedInventoryImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OpennmsDirectScriptedInventory.class);
 
-    public ScriptedInventoryImpl(String scriptPath) {
-        super(scriptPath, 30000, null);
-    }
-
-    public ScriptedInventoryImpl(String scriptPath, long scriptCacheMillis, BundleContext bundleContext) {
+    public OpennmsDirectScriptedInventory(String scriptPath, long scriptCacheMillis, BundleContext bundleContext) {
         super(scriptPath, scriptCacheMillis, bundleContext);
+    }
+    
+    public static OpennmsDirectScriptedInventory withDefaults() {
+        // Empty string results in the default script being loaded
+        return new OpennmsDirectScriptedInventory(DEFAULT_SCRIPT_FULL_PATH, 30000, null);
     }
 
     public void init() {
-        LOG.info("ScriptedInventoryImpl init.");
+        LOG.info("OpennmsDirectScriptedInventory init.");
     }
 
     /**
@@ -106,7 +105,7 @@ public class ScriptedInventoryImpl extends AbstractScriptedInventory implements 
         try {
             return (List<InventoryObject>) getInvocable().invokeFunction("edgeToInventory", edge);
         } catch (Exception e) {
-            throw new ScriptedInventoryException("Failed to create inventory from node", e);
+            throw new ScriptedInventoryException("Failed to create inventory from edge", e);
         }
     }
 }

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/ScriptedInventoryImpl.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/ScriptedInventoryImpl.java
@@ -34,6 +34,7 @@ import javax.script.ScriptException;
 
 import org.opennms.integration.api.v1.model.Alarm;
 import org.opennms.integration.api.v1.model.Node;
+import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.oce.datasource.api.InventoryObject;
 import org.opennms.oce.datasource.common.ImmutableAlarm;
 import org.opennms.oce.datasource.common.inventory.script.AbstractScriptedInventory;
@@ -67,33 +68,45 @@ public class ScriptedInventoryImpl extends AbstractScriptedInventory implements 
      *
      * @param alarmBuilder the alarm builder to update
      * @param alarm the original alarm to derive from
-     * @throws ScriptedInventoryException 
+     * @throws ScriptedInventoryException if the script invocation fails
      */
+    @Override
     public synchronized void overrideTypeAndInstance(ImmutableAlarm.Builder alarmBuilder,
             org.opennms.integration.api.v1.model.Alarm alarm) throws ScriptedInventoryException {
         try {
             getInvocable().invokeFunction("overrideTypeAndInstance", alarmBuilder, alarm);
-        } catch (NoSuchMethodException | ScriptException e) {
+        } catch (Exception e) {
             throw new ScriptedInventoryException("Failed to override inventory for alarm", e);
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized List<InventoryObject> createInventoryObjects(Alarm alarm) throws ScriptedInventoryException {
         try {
             return (List<InventoryObject>) getInvocable().invokeFunction("alarmToInventory", alarm);
-        } catch (NoSuchMethodException | ScriptException e) {
+        } catch (Exception e) {
             throw new ScriptedInventoryException("Failed to create inventory from alarm", e);
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized List<InventoryObject> createInventoryObjects(Node node) throws ScriptedInventoryException {
         try {
             return (List<InventoryObject>) getInvocable().invokeFunction("nodeToInventory", node);
-        } catch (NoSuchMethodException | ScriptException e) {
+        } catch (Exception e) {
             throw new ScriptedInventoryException("Failed to create inventory from node", e);
         }
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<InventoryObject> createInventoryObjects(TopologyEdge edge) throws ScriptedInventoryException {
+        try {
+            return (List<InventoryObject>) getInvocable().invokeFunction("edgeToInventory", edge);
+        } catch (Exception e) {
+            throw new ScriptedInventoryException("Failed to create inventory from node", e);
+        }
+    }
 }

--- a/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/ScriptedInventoryService.java
+++ b/datasource/opennms-direct/src/main/java/org/opennms/oce/datasource/opennms/jvm/ScriptedInventoryService.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import org.opennms.integration.api.v1.model.Alarm;
 import org.opennms.integration.api.v1.model.Node;
+import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.oce.datasource.api.InventoryObject;
 import org.opennms.oce.datasource.common.ImmutableAlarm;
 import org.opennms.oce.datasource.common.inventory.script.ScriptedInventoryException;
@@ -44,5 +45,6 @@ public interface ScriptedInventoryService {
 
     List<InventoryObject> createInventoryObjects(Node node) throws ScriptedInventoryException;
 
+    List<InventoryObject> createInventoryObjects(TopologyEdge edge) throws ScriptedInventoryException;
 
 }

--- a/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,7 @@
     <reference id="edgeDao" interface="org.opennms.integration.api.v1.dao.EdgeDao" />
     <reference id="eventForwarder" interface="org.opennms.integration.api.v1.events.EventForwarder" />
 
-    <bean id="scriptService" class="org.opennms.oce.datasource.opennms.jvm.ScriptedInventoryImpl">
+    <bean id="scriptService" class="org.opennms.oce.datasource.opennms.jvm.OpennmsDirectScriptedInventory">
         <argument value="${scriptFile}"/>
         <argument value="${scriptCacheMillis}"/>
         <argument ref="blueprintBundleContext"/>

--- a/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -5,12 +5,14 @@
         <cm:default-properties>
             <cm:property name="scriptFile" value="" /> <!--  use empty string to use default script included in bundle" -->
             <cm:property name="scriptCacheMillis" value="30000"/>  <!-- 30 seconds -->
+            <cm:property name="topologyProtocols" value="bridge,cdp,isis,lldp,ospf,userdefined"/>
         </cm:default-properties>
     </cm:property-placeholder>
 
     <reference id="alarmDao" interface="org.opennms.integration.api.v1.dao.AlarmDao" />
     <reference id="alarmFeedbackDao" interface="org.opennms.integration.api.v1.dao.AlarmFeedbackDao" />
     <reference id="nodeDao" interface="org.opennms.integration.api.v1.dao.NodeDao" />
+    <reference id="edgeDao" interface="org.opennms.integration.api.v1.dao.EdgeDao" />
     <reference id="eventForwarder" interface="org.opennms.integration.api.v1.events.EventForwarder" />
 
     <bean id="scriptService" class="org.opennms.oce.datasource.opennms.jvm.ScriptedInventoryImpl">
@@ -41,12 +43,17 @@
     <service ref="directAlarmFeedbackDatasource" interface="org.opennms.integration.api.v1.feedback.AlarmFeedbackListener"/>
     <service ref="directAlarmFeedbackDatasource" interface="org.opennms.oce.datasource.api.AlarmFeedbackDatasource"/>
 
-    <bean id="directInventoryDatasource" class="org.opennms.oce.datasource.opennms.jvm.DirectInventoryDatasource" init-method="init" >
+    <!-- Direct Datasource -->
+    <bean id="directInventoryDatasource" class="org.opennms.oce.datasource.opennms.jvm.DirectInventoryDatasource"
+          init-method="init">
         <argument ref="nodeDao"/>
         <argument ref="alarmDao"/>
+        <argument ref="edgeDao"/>
+        <argument value="${topologyProtocols}"/>
         <argument ref="mapper"/>
     </bean>
     <service ref="directInventoryDatasource" interface="org.opennms.oce.datasource.api.InventoryDatasource"/>
     <service ref="directInventoryDatasource" interface="org.opennms.integration.api.v1.alarms.AlarmLifecycleListener"/>
+    <service ref="directInventoryDatasource" interface="org.opennms.integration.api.v1.topology.TopologyEdgeConsumer"/>
 
 </blueprint>

--- a/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-direct/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -5,7 +5,6 @@
         <cm:default-properties>
             <cm:property name="scriptFile" value="" /> <!--  use empty string to use default script included in bundle" -->
             <cm:property name="scriptCacheMillis" value="30000"/>  <!-- 30 seconds -->
-            <cm:property name="topologyProtocols" value="bridge,cdp,isis,lldp,ospf,userdefined"/>
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -49,7 +48,6 @@
         <argument ref="nodeDao"/>
         <argument ref="alarmDao"/>
         <argument ref="edgeDao"/>
-        <argument value="${topologyProtocols}"/>
         <argument ref="mapper"/>
     </bean>
     <service ref="directInventoryDatasource" interface="org.opennms.oce.datasource.api.InventoryDatasource"/>

--- a/datasource/opennms-direct/src/main/resources/inventory.groovy
+++ b/datasource/opennms-direct/src/main/resources/inventory.groovy
@@ -180,7 +180,7 @@ class InventoryFactory {
                 weightForLink.set(SEGMENT_LINK_WEIGHT);
                 ios.add(ImmutableInventoryObject.newBuilder()
                         .setType(ManagedObjectType.Segment.getName())
-                        .setId(Segment.generateId(segment.getId(), segment.getProtocol()))
+                        .setId(Segment.generateId(segment.getId(), segment.getProtocol().name()))
                         .build());
                 // If there was a segment, this edge is a BridgeLink not an SNMP-interface link
                 edgeIoBuilder.setType(ManagedObjectType.BridgeLink.getName());
@@ -190,7 +190,7 @@ class InventoryFactory {
         // Add the source peer (source port)
         edgeIoBuilder.addPeer(ImmutableInventoryObjectPeerRef.newBuilder()
                 .setId(Port.generateId(edge.getSource().getIfIndex(),
-                nodeCriteriaToString(edge.getSource().getNodeCriteria()), edge.getProtocol()))
+                nodeCriteriaToString(edge.getSource().getNodeCriteria()), edge.getProtocol().name()))
                 .setType(ManagedObjectType.SnmpInterface.getName())
                 .setEndpoint(InventoryObjectPeerEndpoint.A)
                 .setWeight(weightForLink.get())
@@ -204,7 +204,7 @@ class InventoryFactory {
                         .setId(generateIdForEdge(edge, port))
                         .addPeer(ImmutableInventoryObjectPeerRef.newBuilder()
                         .setId(Port.generateId(port.getIfIndex(), nodeCriteriaToString(port.getNodeCriteria()),
-                        edge.getProtocol()))
+                        edge.getProtocol().name()))
                         .setType(ManagedObjectType.SnmpInterface.getName())
                         .setEndpoint(InventoryObjectPeerEndpoint.Z)
                         .setWeight(weightForLink.get())
@@ -216,7 +216,7 @@ class InventoryFactory {
                 edgeIoBuilder.setFriendlyName(generateFriendlyNameForEdge(edge, segment))
                         .setId(generateIdForEdge(edge, segment))
                         .addPeer(ImmutableInventoryObjectPeerRef.newBuilder()
-                        .setId(Segment.generateId(segment.getId(), segment.getProtocol()))
+                        .setId(Segment.generateId(segment.getId(), segment.getProtocol().name()))
                         .setType(ManagedObjectType.Segment.getName())
                         .setEndpoint(InventoryObjectPeerEndpoint.Z)
                         .setWeight(weightForLink.get())
@@ -232,25 +232,25 @@ class InventoryFactory {
     private static String generateIdForEdge(TopologyEdge edge, TopologyPort targetPort) {
         return Edge.generateId(edge.getSource().getIfIndex(),
                 nodeCriteriaToString(edge.getSource().getNodeCriteria()), targetPort.getIfIndex(),
-                nodeCriteriaToString(targetPort.getNodeCriteria()), edge.getProtocol());
+                nodeCriteriaToString(targetPort.getNodeCriteria()), edge.getProtocol().name());
     }
 
     private static String generateIdForEdge(TopologyEdge edge, TopologySegment targetSegment) {
         return Edge.generateId(edge.getSource().getIfIndex(),
                 nodeCriteriaToString(edge.getSource().getNodeCriteria()), targetSegment.getSegmentCriteria(),
-                edge.getProtocol());
+                edge.getProtocol().name());
     }
 
     private static String generateFriendlyNameForEdge(TopologyEdge edge, TopologyPort targetPort) {
         return Edge.generateFriendlyName(edge.getSource().getIfIndex(),
                 nodeCriteriaToString(edge.getSource().getNodeCriteria()), targetPort.getIfIndex(),
-                nodeCriteriaToString(targetPort.getNodeCriteria()), edge.getProtocol());
+                nodeCriteriaToString(targetPort.getNodeCriteria()), edge.getProtocol().name());
     }
 
     private static String generateFriendlyNameForEdge(TopologyEdge edge, TopologySegment targetSegment) {
         return Edge.generateFriendlyName(edge.getSource().getIfIndex(),
                 nodeCriteriaToString(edge.getSource().getNodeCriteria()), targetSegment.getSegmentCriteria(),
-                edge.getProtocol());
+                edge.getProtocol().name());
     }
 
     private static String nodeCriteriaToString(NodeCriteria nodeCriteria) {

--- a/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/ApiMapperTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/ApiMapperTest.java
@@ -46,7 +46,7 @@ public class ApiMapperTest {
 
     @Before
     public void setUp() {
-        ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+        ScriptedInventoryService inventoryService = OpennmsDirectScriptedInventory.withDefaults();
         mapper = new ApiMapper(inventoryService);
     }
     /**

--- a/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
@@ -58,8 +58,7 @@ import org.opennms.oce.datasource.common.inventory.ManagedObjectType;
 public class DirectInventoryDatasourceTest {
     private final NodeDao mockNodeDao = mock(NodeDao.class);
     private final AlarmDao mockAlarmDao = mock(AlarmDao.class);
-    private final ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory" +
-            ".groovy");
+    private final ScriptedInventoryService inventoryService = OpennmsDirectScriptedInventory.withDefaults();
     private final ApiMapper mapper = new ApiMapper(inventoryService);
     private final EdgeDao mockEdgeDao = mock(EdgeDao.class);
     private final DirectInventoryDatasource dic = new DirectInventoryDatasource(mockNodeDao, mockAlarmDao,
@@ -217,13 +216,9 @@ public class DirectInventoryDatasourceTest {
         }
 
         @Override
-        public TopologyPort getSource() {
-            return port;
-        }
-
-        @Override
-        public void visitTarget(TopologyEdgeTargetVisitor v) {
-            v.visitTargetSegement(segment);
+        public void visitEndpoints(EndpointVisitor v) {
+            v.visitSource(port);
+            v.visitTarget(segment);
         }
 
         @Override

--- a/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
@@ -49,6 +49,7 @@ import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.NodeCriteria;
 import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.integration.api.v1.model.TopologyPort;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.model.TopologySegment;
 import org.opennms.oce.datasource.api.InventoryHandler;
 import org.opennms.oce.datasource.api.InventoryObject;
@@ -146,7 +147,7 @@ public class DirectInventoryDatasourceTest {
         when(port.getIfIndex()).thenReturn(portIfIndex);
         when(port.getNodeCriteria()).thenReturn(portNodeCriteria);
 
-        String protocol = "protocol";
+        TopologyProtocol protocol = TopologyProtocol.CDP;
         String segmentId = "segment.id";
         String segmentCriteria = "segment:criteria";
         TopologySegment segment = mock(TopologySegment.class);
@@ -199,12 +200,12 @@ public class DirectInventoryDatasourceTest {
     }
 
     private static class EdgeImpl implements TopologyEdge {
-        private final String protocol;
+        private final TopologyProtocol protocol;
         private final String id;
         private final TopologyPort port;
         private final TopologySegment segment;
 
-        public EdgeImpl(String protocol, String id, TopologyPort port, TopologySegment segment) {
+        public EdgeImpl(TopologyProtocol protocol, String id, TopologyPort port, TopologySegment segment) {
             this.protocol = protocol;
             this.id = id;
             this.port = port;
@@ -212,7 +213,7 @@ public class DirectInventoryDatasourceTest {
         }
 
         @Override
-        public String getProtocol() {
+        public TopologyProtocol getProtocol() {
             return protocol;
         }
 

--- a/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/DirectInventoryDatasourceTest.java
@@ -62,9 +62,8 @@ public class DirectInventoryDatasourceTest {
             ".groovy");
     private final ApiMapper mapper = new ApiMapper(inventoryService);
     private final EdgeDao mockEdgeDao = mock(EdgeDao.class);
-    private final String protocols = "";
     private final DirectInventoryDatasource dic = new DirectInventoryDatasource(mockNodeDao, mockAlarmDao,
-            mockEdgeDao, protocols, mapper);
+            mockEdgeDao, mapper);
     private final InventoryHandler inventoryHandler = new InventoryHandlerImpl();
     private final Set<InventoryObject> inventory = new HashSet<>();
 

--- a/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/InventoryFactoryTest.java
+++ b/datasource/opennms-direct/src/test/java/org/opennms/oce/datasource/opennms/jvm/InventoryFactoryTest.java
@@ -54,9 +54,9 @@ public class InventoryFactoryTest {
     private ScriptedInventoryService inventoryService;
 
     @Before
-    public void before() throws IOException, ScriptException, URISyntaxException {
+    public void before() {
         System.setProperty("log4j.skipJansi", "true");
-        inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+        inventoryService = OpennmsDirectScriptedInventory.withDefaults();
     }
 
     @Test

--- a/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/EdgeToInventory.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/EdgeToInventory.java
@@ -62,16 +62,14 @@ public class EdgeToInventory {
     }
 
     @VisibleForTesting
-    static String getIdForEdge(OpennmsModelProtos.TopologyEdge edge) {
-        if (edge.hasTargetPort()) {
-            return Edge.generateId(edge.getSource().getIfIndex(),
-                    OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()),
-                    edge.getTargetPort().getIfIndex(),
-                    OpennmsMapper.toNodeCriteria(edge.getTargetPort().getNodeCriteria()),
-                    edge.getRef().getProtocol().toString());
-        }
-        return Edge.generateId(edge.getSource().getIfIndex(),
-                OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()),
-                edge.getTargetSegment().getRef().getId(), edge.getRef().getProtocol().toString());
+    String getIdForEdge(OpennmsModelProtos.TopologyEdge edge, String type) {
+        InventoryModelProtos.InventoryObjects ioObjects = toInventoryObjects(edge);
+        InventoryModelProtos.InventoryObject edgeIo = ioObjects.getInventoryObjectList()
+                .stream()
+                .filter(io -> io.getType().equals(type))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No edge found"));
+
+        return edgeIo.getId();
     }
 }

--- a/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/EdgeToInventory.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/EdgeToInventory.java
@@ -31,6 +31,10 @@ package org.opennms.oce.datasource.opennms;
 import java.util.Objects;
 
 import org.opennms.oce.datasource.common.inventory.script.ScriptedInventoryException;
+import org.opennms.oce.datasource.common.inventory.Edge;
+import org.opennms.oce.datasource.common.inventory.ManagedObjectType;
+import org.opennms.oce.datasource.common.inventory.Port;
+import org.opennms.oce.datasource.common.inventory.Segment;
 import org.opennms.oce.datasource.opennms.proto.InventoryModelProtos;
 import org.opennms.oce.datasource.opennms.proto.OpennmsModelProtos;
 import org.slf4j.Logger;
@@ -59,8 +63,15 @@ public class EdgeToInventory {
 
     @VisibleForTesting
     static String getIdForEdge(OpennmsModelProtos.TopologyEdge edge) {
-        return String.format("%s:%s:%d:%s:%d", edge.getRef().getProtocol(),
-                OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()), edge.getSource().getIfIndex(),
-                OpennmsMapper.toNodeCriteria(edge.getTargetPort().getNodeCriteria()), edge.getTargetPort().getIfIndex());
+        if (edge.hasTargetPort()) {
+            return Edge.generateId(edge.getSource().getIfIndex(),
+                    OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()),
+                    edge.getTargetPort().getIfIndex(),
+                    OpennmsMapper.toNodeCriteria(edge.getTargetPort().getNodeCriteria()),
+                    edge.getRef().getProtocol().toString());
+        }
+        return Edge.generateId(edge.getSource().getIfIndex(),
+                OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()),
+                edge.getTargetSegment().getRef().getId(), edge.getRef().getProtocol().toString());
     }
 }

--- a/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/OpennmsKafkaScriptedInventory.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/OpennmsKafkaScriptedInventory.java
@@ -47,20 +47,21 @@ import org.slf4j.LoggerFactory;
  * @author smith
  *
  */
-public class ScriptedInventoryImpl extends AbstractScriptedInventory implements ScriptedInventoryService {
+public class OpennmsKafkaScriptedInventory extends AbstractScriptedInventory implements ScriptedInventoryService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ScriptedInventoryImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OpennmsKafkaScriptedInventory.class);
 
-    public ScriptedInventoryImpl(String scriptPath) {
-        super(scriptPath, 30000, null);
-    }
-
-    public ScriptedInventoryImpl(String scriptPath, long scriptCacheMillis, BundleContext bundleContext) {
+    public OpennmsKafkaScriptedInventory(String scriptPath, long scriptCacheMillis, BundleContext bundleContext) {
         super(scriptPath, scriptCacheMillis, bundleContext);
+    }
+    
+    public static OpennmsKafkaScriptedInventory withDefaults() {
+        // Empty string results in the default script being loaded
+        return new OpennmsKafkaScriptedInventory(DEFAULT_SCRIPT_FULL_PATH, 30000, null);
     }
 
     public void init() {
-        LOG.info("ScriptedInventoryImpl init'd");
+        LOG.info("OpennmsKafkaScriptedInventory init'd");
     }
 
     @Override

--- a/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/proto/OpennmsModelProtos.java
+++ b/datasource/opennms-kafka/src/main/java/org/opennms/oce/datasource/opennms/proto/OpennmsModelProtos.java
@@ -16092,6 +16092,10 @@ public final class OpennmsModelProtos {
        * <code>CDP = 4;</code>
        */
       CDP(4),
+      /**
+       * <code>USERDEFINED = 5;</code>
+       */
+      USERDEFINED(5),
       UNRECOGNIZED(-1),
       ;
 
@@ -16115,6 +16119,10 @@ public final class OpennmsModelProtos {
        * <code>CDP = 4;</code>
        */
       public static final int CDP_VALUE = 4;
+      /**
+       * <code>USERDEFINED = 5;</code>
+       */
+      public static final int USERDEFINED_VALUE = 5;
 
 
       public final int getNumber() {
@@ -16140,6 +16148,7 @@ public final class OpennmsModelProtos {
           case 2: return ISIS;
           case 3: return BRIDGE;
           case 4: return CDP;
+          case 5: return USERDEFINED;
           default: return null;
         }
       }
@@ -18359,43 +18368,84 @@ public final class OpennmsModelProtos {
     OpennmsModelProtos.TopologyRefOrBuilder getRefOrBuilder();
 
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    boolean hasSource();
+    boolean hasSourcePort();
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    OpennmsModelProtos.TopologyPort getSource();
+    OpennmsModelProtos.TopologyPort getSourcePort();
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    OpennmsModelProtos.TopologyPortOrBuilder getSourceOrBuilder();
+    OpennmsModelProtos.TopologyPortOrBuilder getSourcePortOrBuilder();
 
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    boolean hasSourceSegment();
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    OpennmsModelProtos.TopologySegment getSourceSegment();
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    OpennmsModelProtos.TopologySegmentOrBuilder getSourceSegmentOrBuilder();
+
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    boolean hasSourceNode();
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    OpennmsModelProtos.Node getSourceNode();
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    OpennmsModelProtos.NodeOrBuilder getSourceNodeOrBuilder();
+
+    /**
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     boolean hasTargetPort();
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     OpennmsModelProtos.TopologyPort getTargetPort();
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     OpennmsModelProtos.TopologyPortOrBuilder getTargetPortOrBuilder();
 
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     boolean hasTargetSegment();
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     OpennmsModelProtos.TopologySegment getTargetSegment();
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     OpennmsModelProtos.TopologySegmentOrBuilder getTargetSegmentOrBuilder();
+
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    boolean hasTargetNode();
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    OpennmsModelProtos.Node getTargetNode();
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    OpennmsModelProtos.NodeOrBuilder getTargetNodeOrBuilder();
+
+    public OpennmsModelProtos.TopologyEdge.SourceCase getSourceCase();
 
     public OpennmsModelProtos.TopologyEdge.TargetCase getTargetCase();
   }
@@ -18458,22 +18508,51 @@ public final class OpennmsModelProtos {
 
               break;
             }
-            case 18: {
-              OpennmsModelProtos.TopologyPort.Builder subBuilder = null;
-              if (source_ != null) {
-                subBuilder = source_.toBuilder();
-              }
-              source_ = input.readMessage(OpennmsModelProtos.TopologyPort.parser(), extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(source_);
-                source_ = subBuilder.buildPartial();
-              }
-
-              break;
-            }
             case 26: {
               OpennmsModelProtos.TopologyPort.Builder subBuilder = null;
-              if (targetCase_ == 3) {
+              if (sourceCase_ == 3) {
+                subBuilder = ((OpennmsModelProtos.TopologyPort) source_).toBuilder();
+              }
+              source_ =
+                  input.readMessage(OpennmsModelProtos.TopologyPort.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((OpennmsModelProtos.TopologyPort) source_);
+                source_ = subBuilder.buildPartial();
+              }
+              sourceCase_ = 3;
+              break;
+            }
+            case 34: {
+              OpennmsModelProtos.TopologySegment.Builder subBuilder = null;
+              if (sourceCase_ == 4) {
+                subBuilder = ((OpennmsModelProtos.TopologySegment) source_).toBuilder();
+              }
+              source_ =
+                  input.readMessage(OpennmsModelProtos.TopologySegment.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((OpennmsModelProtos.TopologySegment) source_);
+                source_ = subBuilder.buildPartial();
+              }
+              sourceCase_ = 4;
+              break;
+            }
+            case 42: {
+              OpennmsModelProtos.Node.Builder subBuilder = null;
+              if (sourceCase_ == 5) {
+                subBuilder = ((OpennmsModelProtos.Node) source_).toBuilder();
+              }
+              source_ =
+                  input.readMessage(OpennmsModelProtos.Node.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((OpennmsModelProtos.Node) source_);
+                source_ = subBuilder.buildPartial();
+              }
+              sourceCase_ = 5;
+              break;
+            }
+            case 50: {
+              OpennmsModelProtos.TopologyPort.Builder subBuilder = null;
+              if (targetCase_ == 6) {
                 subBuilder = ((OpennmsModelProtos.TopologyPort) target_).toBuilder();
               }
               target_ =
@@ -18482,12 +18561,12 @@ public final class OpennmsModelProtos {
                 subBuilder.mergeFrom((OpennmsModelProtos.TopologyPort) target_);
                 target_ = subBuilder.buildPartial();
               }
-              targetCase_ = 3;
+              targetCase_ = 6;
               break;
             }
-            case 34: {
+            case 58: {
               OpennmsModelProtos.TopologySegment.Builder subBuilder = null;
-              if (targetCase_ == 4) {
+              if (targetCase_ == 7) {
                 subBuilder = ((OpennmsModelProtos.TopologySegment) target_).toBuilder();
               }
               target_ =
@@ -18496,7 +18575,21 @@ public final class OpennmsModelProtos {
                 subBuilder.mergeFrom((OpennmsModelProtos.TopologySegment) target_);
                 target_ = subBuilder.buildPartial();
               }
-              targetCase_ = 4;
+              targetCase_ = 7;
+              break;
+            }
+            case 66: {
+              OpennmsModelProtos.Node.Builder subBuilder = null;
+              if (targetCase_ == 8) {
+                subBuilder = ((OpennmsModelProtos.Node) target_).toBuilder();
+              }
+              target_ =
+                  input.readMessage(OpennmsModelProtos.Node.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((OpennmsModelProtos.Node) target_);
+                target_ = subBuilder.buildPartial();
+              }
+              targetCase_ = 8;
               break;
             }
           }
@@ -18523,12 +18616,53 @@ public final class OpennmsModelProtos {
               OpennmsModelProtos.TopologyEdge.class, OpennmsModelProtos.TopologyEdge.Builder.class);
     }
 
+    private int sourceCase_ = 0;
+    private java.lang.Object source_;
+    public enum SourceCase
+        implements com.google.protobuf.Internal.EnumLite {
+      SOURCEPORT(3),
+      SOURCESEGMENT(4),
+      SOURCENODE(5),
+      SOURCE_NOT_SET(0);
+      private final int value;
+      private SourceCase(int value) {
+        this.value = value;
+      }
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
+      public static SourceCase valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static SourceCase forNumber(int value) {
+        switch (value) {
+          case 3: return SOURCEPORT;
+          case 4: return SOURCESEGMENT;
+          case 5: return SOURCENODE;
+          case 0: return SOURCE_NOT_SET;
+          default: return null;
+        }
+      }
+      public int getNumber() {
+        return this.value;
+      }
+    };
+
+    public SourceCase
+    getSourceCase() {
+      return SourceCase.forNumber(
+          sourceCase_);
+    }
+
     private int targetCase_ = 0;
     private java.lang.Object target_;
     public enum TargetCase
         implements com.google.protobuf.Internal.EnumLite {
-      TARGETPORT(3),
-      TARGETSEGMENT(4),
+      TARGETPORT(6),
+      TARGETSEGMENT(7),
+      TARGETNODE(8),
       TARGET_NOT_SET(0);
       private final int value;
       private TargetCase(int value) {
@@ -18544,8 +18678,9 @@ public final class OpennmsModelProtos {
 
       public static TargetCase forNumber(int value) {
         switch (value) {
-          case 3: return TARGETPORT;
-          case 4: return TARGETSEGMENT;
+          case 6: return TARGETPORT;
+          case 7: return TARGETSEGMENT;
+          case 8: return TARGETNODE;
           case 0: return TARGET_NOT_SET;
           default: return null;
         }
@@ -18582,77 +18717,160 @@ public final class OpennmsModelProtos {
       return getRef();
     }
 
-    public static final int SOURCE_FIELD_NUMBER = 2;
-    private OpennmsModelProtos.TopologyPort source_;
+    public static final int SOURCEPORT_FIELD_NUMBER = 3;
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    public boolean hasSource() {
-      return source_ != null;
+    public boolean hasSourcePort() {
+      return sourceCase_ == 3;
     }
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    public OpennmsModelProtos.TopologyPort getSource() {
-      return source_ == null ? OpennmsModelProtos.TopologyPort.getDefaultInstance() : source_;
+    public OpennmsModelProtos.TopologyPort getSourcePort() {
+      if (sourceCase_ == 3) {
+         return (OpennmsModelProtos.TopologyPort) source_;
+      }
+      return OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    public OpennmsModelProtos.TopologyPortOrBuilder getSourceOrBuilder() {
-      return getSource();
+    public OpennmsModelProtos.TopologyPortOrBuilder getSourcePortOrBuilder() {
+      if (sourceCase_ == 3) {
+         return (OpennmsModelProtos.TopologyPort) source_;
+      }
+      return OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
 
-    public static final int TARGETPORT_FIELD_NUMBER = 3;
+    public static final int SOURCESEGMENT_FIELD_NUMBER = 4;
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    public boolean hasSourceSegment() {
+      return sourceCase_ == 4;
+    }
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    public OpennmsModelProtos.TopologySegment getSourceSegment() {
+      if (sourceCase_ == 4) {
+         return (OpennmsModelProtos.TopologySegment) source_;
+      }
+      return OpennmsModelProtos.TopologySegment.getDefaultInstance();
+    }
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    public OpennmsModelProtos.TopologySegmentOrBuilder getSourceSegmentOrBuilder() {
+      if (sourceCase_ == 4) {
+         return (OpennmsModelProtos.TopologySegment) source_;
+      }
+      return OpennmsModelProtos.TopologySegment.getDefaultInstance();
+    }
+
+    public static final int SOURCENODE_FIELD_NUMBER = 5;
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    public boolean hasSourceNode() {
+      return sourceCase_ == 5;
+    }
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    public OpennmsModelProtos.Node getSourceNode() {
+      if (sourceCase_ == 5) {
+         return (OpennmsModelProtos.Node) source_;
+      }
+      return OpennmsModelProtos.Node.getDefaultInstance();
+    }
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    public OpennmsModelProtos.NodeOrBuilder getSourceNodeOrBuilder() {
+      if (sourceCase_ == 5) {
+         return (OpennmsModelProtos.Node) source_;
+      }
+      return OpennmsModelProtos.Node.getDefaultInstance();
+    }
+
+    public static final int TARGETPORT_FIELD_NUMBER = 6;
+    /**
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     public boolean hasTargetPort() {
-      return targetCase_ == 3;
+      return targetCase_ == 6;
     }
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     public OpennmsModelProtos.TopologyPort getTargetPort() {
-      if (targetCase_ == 3) {
+      if (targetCase_ == 6) {
          return (OpennmsModelProtos.TopologyPort) target_;
       }
       return OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     public OpennmsModelProtos.TopologyPortOrBuilder getTargetPortOrBuilder() {
-      if (targetCase_ == 3) {
+      if (targetCase_ == 6) {
          return (OpennmsModelProtos.TopologyPort) target_;
       }
       return OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
 
-    public static final int TARGETSEGMENT_FIELD_NUMBER = 4;
+    public static final int TARGETSEGMENT_FIELD_NUMBER = 7;
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     public boolean hasTargetSegment() {
-      return targetCase_ == 4;
+      return targetCase_ == 7;
     }
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     public OpennmsModelProtos.TopologySegment getTargetSegment() {
-      if (targetCase_ == 4) {
+      if (targetCase_ == 7) {
          return (OpennmsModelProtos.TopologySegment) target_;
       }
       return OpennmsModelProtos.TopologySegment.getDefaultInstance();
     }
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     public OpennmsModelProtos.TopologySegmentOrBuilder getTargetSegmentOrBuilder() {
-      if (targetCase_ == 4) {
+      if (targetCase_ == 7) {
          return (OpennmsModelProtos.TopologySegment) target_;
       }
       return OpennmsModelProtos.TopologySegment.getDefaultInstance();
+    }
+
+    public static final int TARGETNODE_FIELD_NUMBER = 8;
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    public boolean hasTargetNode() {
+      return targetCase_ == 8;
+    }
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    public OpennmsModelProtos.Node getTargetNode() {
+      if (targetCase_ == 8) {
+         return (OpennmsModelProtos.Node) target_;
+      }
+      return OpennmsModelProtos.Node.getDefaultInstance();
+    }
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    public OpennmsModelProtos.NodeOrBuilder getTargetNodeOrBuilder() {
+      if (targetCase_ == 8) {
+         return (OpennmsModelProtos.Node) target_;
+      }
+      return OpennmsModelProtos.Node.getDefaultInstance();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -18670,14 +18888,23 @@ public final class OpennmsModelProtos {
       if (ref_ != null) {
         output.writeMessage(1, getRef());
       }
-      if (source_ != null) {
-        output.writeMessage(2, getSource());
+      if (sourceCase_ == 3) {
+        output.writeMessage(3, (OpennmsModelProtos.TopologyPort) source_);
       }
-      if (targetCase_ == 3) {
-        output.writeMessage(3, (OpennmsModelProtos.TopologyPort) target_);
+      if (sourceCase_ == 4) {
+        output.writeMessage(4, (OpennmsModelProtos.TopologySegment) source_);
       }
-      if (targetCase_ == 4) {
-        output.writeMessage(4, (OpennmsModelProtos.TopologySegment) target_);
+      if (sourceCase_ == 5) {
+        output.writeMessage(5, (OpennmsModelProtos.Node) source_);
+      }
+      if (targetCase_ == 6) {
+        output.writeMessage(6, (OpennmsModelProtos.TopologyPort) target_);
+      }
+      if (targetCase_ == 7) {
+        output.writeMessage(7, (OpennmsModelProtos.TopologySegment) target_);
+      }
+      if (targetCase_ == 8) {
+        output.writeMessage(8, (OpennmsModelProtos.Node) target_);
       }
       unknownFields.writeTo(output);
     }
@@ -18691,17 +18918,29 @@ public final class OpennmsModelProtos {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getRef());
       }
-      if (source_ != null) {
+      if (sourceCase_ == 3) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, getSource());
+          .computeMessageSize(3, (OpennmsModelProtos.TopologyPort) source_);
       }
-      if (targetCase_ == 3) {
+      if (sourceCase_ == 4) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, (OpennmsModelProtos.TopologyPort) target_);
+          .computeMessageSize(4, (OpennmsModelProtos.TopologySegment) source_);
       }
-      if (targetCase_ == 4) {
+      if (sourceCase_ == 5) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(4, (OpennmsModelProtos.TopologySegment) target_);
+          .computeMessageSize(5, (OpennmsModelProtos.Node) source_);
+      }
+      if (targetCase_ == 6) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, (OpennmsModelProtos.TopologyPort) target_);
+      }
+      if (targetCase_ == 7) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(7, (OpennmsModelProtos.TopologySegment) target_);
+      }
+      if (targetCase_ == 8) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, (OpennmsModelProtos.Node) target_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -18724,22 +18963,40 @@ public final class OpennmsModelProtos {
         result = result && getRef()
             .equals(other.getRef());
       }
-      result = result && (hasSource() == other.hasSource());
-      if (hasSource()) {
-        result = result && getSource()
-            .equals(other.getSource());
+      result = result && getSourceCase().equals(
+          other.getSourceCase());
+      if (!result) return false;
+      switch (sourceCase_) {
+        case 3:
+          result = result && getSourcePort()
+              .equals(other.getSourcePort());
+          break;
+        case 4:
+          result = result && getSourceSegment()
+              .equals(other.getSourceSegment());
+          break;
+        case 5:
+          result = result && getSourceNode()
+              .equals(other.getSourceNode());
+          break;
+        case 0:
+        default:
       }
       result = result && getTargetCase().equals(
           other.getTargetCase());
       if (!result) return false;
       switch (targetCase_) {
-        case 3:
+        case 6:
           result = result && getTargetPort()
               .equals(other.getTargetPort());
           break;
-        case 4:
+        case 7:
           result = result && getTargetSegment()
               .equals(other.getTargetSegment());
+          break;
+        case 8:
+          result = result && getTargetNode()
+              .equals(other.getTargetNode());
           break;
         case 0:
         default:
@@ -18759,18 +19016,34 @@ public final class OpennmsModelProtos {
         hash = (37 * hash) + REF_FIELD_NUMBER;
         hash = (53 * hash) + getRef().hashCode();
       }
-      if (hasSource()) {
-        hash = (37 * hash) + SOURCE_FIELD_NUMBER;
-        hash = (53 * hash) + getSource().hashCode();
+      switch (sourceCase_) {
+        case 3:
+          hash = (37 * hash) + SOURCEPORT_FIELD_NUMBER;
+          hash = (53 * hash) + getSourcePort().hashCode();
+          break;
+        case 4:
+          hash = (37 * hash) + SOURCESEGMENT_FIELD_NUMBER;
+          hash = (53 * hash) + getSourceSegment().hashCode();
+          break;
+        case 5:
+          hash = (37 * hash) + SOURCENODE_FIELD_NUMBER;
+          hash = (53 * hash) + getSourceNode().hashCode();
+          break;
+        case 0:
+        default:
       }
       switch (targetCase_) {
-        case 3:
+        case 6:
           hash = (37 * hash) + TARGETPORT_FIELD_NUMBER;
           hash = (53 * hash) + getTargetPort().hashCode();
           break;
-        case 4:
+        case 7:
           hash = (37 * hash) + TARGETSEGMENT_FIELD_NUMBER;
           hash = (53 * hash) + getTargetSegment().hashCode();
+          break;
+        case 8:
+          hash = (37 * hash) + TARGETNODE_FIELD_NUMBER;
+          hash = (53 * hash) + getTargetNode().hashCode();
           break;
         case 0:
         default:
@@ -18910,12 +19183,8 @@ public final class OpennmsModelProtos {
           ref_ = null;
           refBuilder_ = null;
         }
-        if (sourceBuilder_ == null) {
-          source_ = null;
-        } else {
-          source_ = null;
-          sourceBuilder_ = null;
-        }
+        sourceCase_ = 0;
+        source_ = null;
         targetCase_ = 0;
         target_ = null;
         return this;
@@ -18945,25 +19214,49 @@ public final class OpennmsModelProtos {
         } else {
           result.ref_ = refBuilder_.build();
         }
-        if (sourceBuilder_ == null) {
-          result.source_ = source_;
-        } else {
-          result.source_ = sourceBuilder_.build();
+        if (sourceCase_ == 3) {
+          if (sourcePortBuilder_ == null) {
+            result.source_ = source_;
+          } else {
+            result.source_ = sourcePortBuilder_.build();
+          }
         }
-        if (targetCase_ == 3) {
+        if (sourceCase_ == 4) {
+          if (sourceSegmentBuilder_ == null) {
+            result.source_ = source_;
+          } else {
+            result.source_ = sourceSegmentBuilder_.build();
+          }
+        }
+        if (sourceCase_ == 5) {
+          if (sourceNodeBuilder_ == null) {
+            result.source_ = source_;
+          } else {
+            result.source_ = sourceNodeBuilder_.build();
+          }
+        }
+        if (targetCase_ == 6) {
           if (targetPortBuilder_ == null) {
             result.target_ = target_;
           } else {
             result.target_ = targetPortBuilder_.build();
           }
         }
-        if (targetCase_ == 4) {
+        if (targetCase_ == 7) {
           if (targetSegmentBuilder_ == null) {
             result.target_ = target_;
           } else {
             result.target_ = targetSegmentBuilder_.build();
           }
         }
+        if (targetCase_ == 8) {
+          if (targetNodeBuilder_ == null) {
+            result.target_ = target_;
+          } else {
+            result.target_ = targetNodeBuilder_.build();
+          }
+        }
+        result.sourceCase_ = sourceCase_;
         result.targetCase_ = targetCase_;
         onBuilt();
         return result;
@@ -19009,8 +19302,22 @@ public final class OpennmsModelProtos {
         if (other.hasRef()) {
           mergeRef(other.getRef());
         }
-        if (other.hasSource()) {
-          mergeSource(other.getSource());
+        switch (other.getSourceCase()) {
+          case SOURCEPORT: {
+            mergeSourcePort(other.getSourcePort());
+            break;
+          }
+          case SOURCESEGMENT: {
+            mergeSourceSegment(other.getSourceSegment());
+            break;
+          }
+          case SOURCENODE: {
+            mergeSourceNode(other.getSourceNode());
+            break;
+          }
+          case SOURCE_NOT_SET: {
+            break;
+          }
         }
         switch (other.getTargetCase()) {
           case TARGETPORT: {
@@ -19019,6 +19326,10 @@ public final class OpennmsModelProtos {
           }
           case TARGETSEGMENT: {
             mergeTargetSegment(other.getTargetSegment());
+            break;
+          }
+          case TARGETNODE: {
+            mergeTargetNode(other.getTargetNode());
             break;
           }
           case TARGET_NOT_SET: {
@@ -19051,6 +19362,21 @@ public final class OpennmsModelProtos {
         }
         return this;
       }
+      private int sourceCase_ = 0;
+      private java.lang.Object source_;
+      public SourceCase
+          getSourceCase() {
+        return SourceCase.forNumber(
+            sourceCase_);
+      }
+
+      public Builder clearSource() {
+        sourceCase_ = 0;
+        source_ = null;
+        onChanged();
+        return this;
+      }
+
       private int targetCase_ = 0;
       private java.lang.Object target_;
       public TargetCase
@@ -19184,149 +19510,440 @@ public final class OpennmsModelProtos {
         return refBuilder_;
       }
 
-      private OpennmsModelProtos.TopologyPort source_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
-          OpennmsModelProtos.TopologyPort, OpennmsModelProtos.TopologyPort.Builder, OpennmsModelProtos.TopologyPortOrBuilder> sourceBuilder_;
+          OpennmsModelProtos.TopologyPort, OpennmsModelProtos.TopologyPort.Builder, OpennmsModelProtos.TopologyPortOrBuilder> sourcePortBuilder_;
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public boolean hasSource() {
-        return sourceBuilder_ != null || source_ != null;
+      public boolean hasSourcePort() {
+        return sourceCase_ == 3;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public OpennmsModelProtos.TopologyPort getSource() {
-        if (sourceBuilder_ == null) {
-          return source_ == null ? OpennmsModelProtos.TopologyPort.getDefaultInstance() : source_;
+      public OpennmsModelProtos.TopologyPort getSourcePort() {
+        if (sourcePortBuilder_ == null) {
+          if (sourceCase_ == 3) {
+            return (OpennmsModelProtos.TopologyPort) source_;
+          }
+          return OpennmsModelProtos.TopologyPort.getDefaultInstance();
         } else {
-          return sourceBuilder_.getMessage();
+          if (sourceCase_ == 3) {
+            return sourcePortBuilder_.getMessage();
+          }
+          return OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder setSource(OpennmsModelProtos.TopologyPort value) {
-        if (sourceBuilder_ == null) {
+      public Builder setSourcePort(OpennmsModelProtos.TopologyPort value) {
+        if (sourcePortBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           source_ = value;
           onChanged();
         } else {
-          sourceBuilder_.setMessage(value);
+          sourcePortBuilder_.setMessage(value);
         }
-
+        sourceCase_ = 3;
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder setSource(
+      public Builder setSourcePort(
           OpennmsModelProtos.TopologyPort.Builder builderForValue) {
-        if (sourceBuilder_ == null) {
+        if (sourcePortBuilder_ == null) {
           source_ = builderForValue.build();
           onChanged();
         } else {
-          sourceBuilder_.setMessage(builderForValue.build());
+          sourcePortBuilder_.setMessage(builderForValue.build());
         }
-
+        sourceCase_ = 3;
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder mergeSource(OpennmsModelProtos.TopologyPort value) {
-        if (sourceBuilder_ == null) {
-          if (source_ != null) {
-            source_ =
-              OpennmsModelProtos.TopologyPort.newBuilder(source_).mergeFrom(value).buildPartial();
+      public Builder mergeSourcePort(OpennmsModelProtos.TopologyPort value) {
+        if (sourcePortBuilder_ == null) {
+          if (sourceCase_ == 3 &&
+              source_ != OpennmsModelProtos.TopologyPort.getDefaultInstance()) {
+            source_ = OpennmsModelProtos.TopologyPort.newBuilder((OpennmsModelProtos.TopologyPort) source_)
+                .mergeFrom(value).buildPartial();
           } else {
             source_ = value;
           }
           onChanged();
         } else {
-          sourceBuilder_.mergeFrom(value);
+          if (sourceCase_ == 3) {
+            sourcePortBuilder_.mergeFrom(value);
+          }
+          sourcePortBuilder_.setMessage(value);
         }
-
+        sourceCase_ = 3;
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder clearSource() {
-        if (sourceBuilder_ == null) {
-          source_ = null;
-          onChanged();
+      public Builder clearSourcePort() {
+        if (sourcePortBuilder_ == null) {
+          if (sourceCase_ == 3) {
+            sourceCase_ = 0;
+            source_ = null;
+            onChanged();
+          }
         } else {
-          source_ = null;
-          sourceBuilder_ = null;
+          if (sourceCase_ == 3) {
+            sourceCase_ = 0;
+            source_ = null;
+          }
+          sourcePortBuilder_.clear();
         }
-
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public OpennmsModelProtos.TopologyPort.Builder getSourceBuilder() {
-        
-        onChanged();
-        return getSourceFieldBuilder().getBuilder();
+      public OpennmsModelProtos.TopologyPort.Builder getSourcePortBuilder() {
+        return getSourcePortFieldBuilder().getBuilder();
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public OpennmsModelProtos.TopologyPortOrBuilder getSourceOrBuilder() {
-        if (sourceBuilder_ != null) {
-          return sourceBuilder_.getMessageOrBuilder();
+      public OpennmsModelProtos.TopologyPortOrBuilder getSourcePortOrBuilder() {
+        if ((sourceCase_ == 3) && (sourcePortBuilder_ != null)) {
+          return sourcePortBuilder_.getMessageOrBuilder();
         } else {
-          return source_ == null ?
-              OpennmsModelProtos.TopologyPort.getDefaultInstance() : source_;
+          if (sourceCase_ == 3) {
+            return (OpennmsModelProtos.TopologyPort) source_;
+          }
+          return OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           OpennmsModelProtos.TopologyPort, OpennmsModelProtos.TopologyPort.Builder, OpennmsModelProtos.TopologyPortOrBuilder> 
-          getSourceFieldBuilder() {
-        if (sourceBuilder_ == null) {
-          sourceBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+          getSourcePortFieldBuilder() {
+        if (sourcePortBuilder_ == null) {
+          if (!(sourceCase_ == 3)) {
+            source_ = OpennmsModelProtos.TopologyPort.getDefaultInstance();
+          }
+          sourcePortBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               OpennmsModelProtos.TopologyPort, OpennmsModelProtos.TopologyPort.Builder, OpennmsModelProtos.TopologyPortOrBuilder>(
-                  getSource(),
+                  (OpennmsModelProtos.TopologyPort) source_,
                   getParentForChildren(),
                   isClean());
           source_ = null;
         }
-        return sourceBuilder_;
+        sourceCase_ = 3;
+        onChanged();;
+        return sourcePortBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          OpennmsModelProtos.TopologySegment, OpennmsModelProtos.TopologySegment.Builder, OpennmsModelProtos.TopologySegmentOrBuilder> sourceSegmentBuilder_;
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public boolean hasSourceSegment() {
+        return sourceCase_ == 4;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public OpennmsModelProtos.TopologySegment getSourceSegment() {
+        if (sourceSegmentBuilder_ == null) {
+          if (sourceCase_ == 4) {
+            return (OpennmsModelProtos.TopologySegment) source_;
+          }
+          return OpennmsModelProtos.TopologySegment.getDefaultInstance();
+        } else {
+          if (sourceCase_ == 4) {
+            return sourceSegmentBuilder_.getMessage();
+          }
+          return OpennmsModelProtos.TopologySegment.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder setSourceSegment(OpennmsModelProtos.TopologySegment value) {
+        if (sourceSegmentBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          source_ = value;
+          onChanged();
+        } else {
+          sourceSegmentBuilder_.setMessage(value);
+        }
+        sourceCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder setSourceSegment(
+          OpennmsModelProtos.TopologySegment.Builder builderForValue) {
+        if (sourceSegmentBuilder_ == null) {
+          source_ = builderForValue.build();
+          onChanged();
+        } else {
+          sourceSegmentBuilder_.setMessage(builderForValue.build());
+        }
+        sourceCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder mergeSourceSegment(OpennmsModelProtos.TopologySegment value) {
+        if (sourceSegmentBuilder_ == null) {
+          if (sourceCase_ == 4 &&
+              source_ != OpennmsModelProtos.TopologySegment.getDefaultInstance()) {
+            source_ = OpennmsModelProtos.TopologySegment.newBuilder((OpennmsModelProtos.TopologySegment) source_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            source_ = value;
+          }
+          onChanged();
+        } else {
+          if (sourceCase_ == 4) {
+            sourceSegmentBuilder_.mergeFrom(value);
+          }
+          sourceSegmentBuilder_.setMessage(value);
+        }
+        sourceCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder clearSourceSegment() {
+        if (sourceSegmentBuilder_ == null) {
+          if (sourceCase_ == 4) {
+            sourceCase_ = 0;
+            source_ = null;
+            onChanged();
+          }
+        } else {
+          if (sourceCase_ == 4) {
+            sourceCase_ = 0;
+            source_ = null;
+          }
+          sourceSegmentBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public OpennmsModelProtos.TopologySegment.Builder getSourceSegmentBuilder() {
+        return getSourceSegmentFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public OpennmsModelProtos.TopologySegmentOrBuilder getSourceSegmentOrBuilder() {
+        if ((sourceCase_ == 4) && (sourceSegmentBuilder_ != null)) {
+          return sourceSegmentBuilder_.getMessageOrBuilder();
+        } else {
+          if (sourceCase_ == 4) {
+            return (OpennmsModelProtos.TopologySegment) source_;
+          }
+          return OpennmsModelProtos.TopologySegment.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          OpennmsModelProtos.TopologySegment, OpennmsModelProtos.TopologySegment.Builder, OpennmsModelProtos.TopologySegmentOrBuilder> 
+          getSourceSegmentFieldBuilder() {
+        if (sourceSegmentBuilder_ == null) {
+          if (!(sourceCase_ == 4)) {
+            source_ = OpennmsModelProtos.TopologySegment.getDefaultInstance();
+          }
+          sourceSegmentBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              OpennmsModelProtos.TopologySegment, OpennmsModelProtos.TopologySegment.Builder, OpennmsModelProtos.TopologySegmentOrBuilder>(
+                  (OpennmsModelProtos.TopologySegment) source_,
+                  getParentForChildren(),
+                  isClean());
+          source_ = null;
+        }
+        sourceCase_ = 4;
+        onChanged();;
+        return sourceSegmentBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          OpennmsModelProtos.Node, OpennmsModelProtos.Node.Builder, OpennmsModelProtos.NodeOrBuilder> sourceNodeBuilder_;
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public boolean hasSourceNode() {
+        return sourceCase_ == 5;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public OpennmsModelProtos.Node getSourceNode() {
+        if (sourceNodeBuilder_ == null) {
+          if (sourceCase_ == 5) {
+            return (OpennmsModelProtos.Node) source_;
+          }
+          return OpennmsModelProtos.Node.getDefaultInstance();
+        } else {
+          if (sourceCase_ == 5) {
+            return sourceNodeBuilder_.getMessage();
+          }
+          return OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder setSourceNode(OpennmsModelProtos.Node value) {
+        if (sourceNodeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          source_ = value;
+          onChanged();
+        } else {
+          sourceNodeBuilder_.setMessage(value);
+        }
+        sourceCase_ = 5;
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder setSourceNode(
+          OpennmsModelProtos.Node.Builder builderForValue) {
+        if (sourceNodeBuilder_ == null) {
+          source_ = builderForValue.build();
+          onChanged();
+        } else {
+          sourceNodeBuilder_.setMessage(builderForValue.build());
+        }
+        sourceCase_ = 5;
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder mergeSourceNode(OpennmsModelProtos.Node value) {
+        if (sourceNodeBuilder_ == null) {
+          if (sourceCase_ == 5 &&
+              source_ != OpennmsModelProtos.Node.getDefaultInstance()) {
+            source_ = OpennmsModelProtos.Node.newBuilder((OpennmsModelProtos.Node) source_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            source_ = value;
+          }
+          onChanged();
+        } else {
+          if (sourceCase_ == 5) {
+            sourceNodeBuilder_.mergeFrom(value);
+          }
+          sourceNodeBuilder_.setMessage(value);
+        }
+        sourceCase_ = 5;
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder clearSourceNode() {
+        if (sourceNodeBuilder_ == null) {
+          if (sourceCase_ == 5) {
+            sourceCase_ = 0;
+            source_ = null;
+            onChanged();
+          }
+        } else {
+          if (sourceCase_ == 5) {
+            sourceCase_ = 0;
+            source_ = null;
+          }
+          sourceNodeBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public OpennmsModelProtos.Node.Builder getSourceNodeBuilder() {
+        return getSourceNodeFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public OpennmsModelProtos.NodeOrBuilder getSourceNodeOrBuilder() {
+        if ((sourceCase_ == 5) && (sourceNodeBuilder_ != null)) {
+          return sourceNodeBuilder_.getMessageOrBuilder();
+        } else {
+          if (sourceCase_ == 5) {
+            return (OpennmsModelProtos.Node) source_;
+          }
+          return OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          OpennmsModelProtos.Node, OpennmsModelProtos.Node.Builder, OpennmsModelProtos.NodeOrBuilder> 
+          getSourceNodeFieldBuilder() {
+        if (sourceNodeBuilder_ == null) {
+          if (!(sourceCase_ == 5)) {
+            source_ = OpennmsModelProtos.Node.getDefaultInstance();
+          }
+          sourceNodeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              OpennmsModelProtos.Node, OpennmsModelProtos.Node.Builder, OpennmsModelProtos.NodeOrBuilder>(
+                  (OpennmsModelProtos.Node) source_,
+                  getParentForChildren(),
+                  isClean());
+          source_ = null;
+        }
+        sourceCase_ = 5;
+        onChanged();;
+        return sourceNodeBuilder_;
       }
 
       private com.google.protobuf.SingleFieldBuilderV3<
           OpennmsModelProtos.TopologyPort, OpennmsModelProtos.TopologyPort.Builder, OpennmsModelProtos.TopologyPortOrBuilder> targetPortBuilder_;
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public boolean hasTargetPort() {
-        return targetCase_ == 3;
+        return targetCase_ == 6;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public OpennmsModelProtos.TopologyPort getTargetPort() {
         if (targetPortBuilder_ == null) {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             return (OpennmsModelProtos.TopologyPort) target_;
           }
           return OpennmsModelProtos.TopologyPort.getDefaultInstance();
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             return targetPortBuilder_.getMessage();
           }
           return OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder setTargetPort(OpennmsModelProtos.TopologyPort value) {
         if (targetPortBuilder_ == null) {
@@ -19338,11 +19955,11 @@ public final class OpennmsModelProtos {
         } else {
           targetPortBuilder_.setMessage(value);
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder setTargetPort(
           OpennmsModelProtos.TopologyPort.Builder builderForValue) {
@@ -19352,15 +19969,15 @@ public final class OpennmsModelProtos {
         } else {
           targetPortBuilder_.setMessage(builderForValue.build());
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder mergeTargetPort(OpennmsModelProtos.TopologyPort value) {
         if (targetPortBuilder_ == null) {
-          if (targetCase_ == 3 &&
+          if (targetCase_ == 6 &&
               target_ != OpennmsModelProtos.TopologyPort.getDefaultInstance()) {
             target_ = OpennmsModelProtos.TopologyPort.newBuilder((OpennmsModelProtos.TopologyPort) target_)
                 .mergeFrom(value).buildPartial();
@@ -19369,26 +19986,26 @@ public final class OpennmsModelProtos {
           }
           onChanged();
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             targetPortBuilder_.mergeFrom(value);
           }
           targetPortBuilder_.setMessage(value);
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder clearTargetPort() {
         if (targetPortBuilder_ == null) {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             targetCase_ = 0;
             target_ = null;
             onChanged();
           }
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             targetCase_ = 0;
             target_ = null;
           }
@@ -19397,32 +20014,32 @@ public final class OpennmsModelProtos {
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public OpennmsModelProtos.TopologyPort.Builder getTargetPortBuilder() {
         return getTargetPortFieldBuilder().getBuilder();
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public OpennmsModelProtos.TopologyPortOrBuilder getTargetPortOrBuilder() {
-        if ((targetCase_ == 3) && (targetPortBuilder_ != null)) {
+        if ((targetCase_ == 6) && (targetPortBuilder_ != null)) {
           return targetPortBuilder_.getMessageOrBuilder();
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             return (OpennmsModelProtos.TopologyPort) target_;
           }
           return OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           OpennmsModelProtos.TopologyPort, OpennmsModelProtos.TopologyPort.Builder, OpennmsModelProtos.TopologyPortOrBuilder> 
           getTargetPortFieldBuilder() {
         if (targetPortBuilder_ == null) {
-          if (!(targetCase_ == 3)) {
+          if (!(targetCase_ == 6)) {
             target_ = OpennmsModelProtos.TopologyPort.getDefaultInstance();
           }
           targetPortBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
@@ -19432,7 +20049,7 @@ public final class OpennmsModelProtos {
                   isClean());
           target_ = null;
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         onChanged();;
         return targetPortBuilder_;
       }
@@ -19440,29 +20057,29 @@ public final class OpennmsModelProtos {
       private com.google.protobuf.SingleFieldBuilderV3<
           OpennmsModelProtos.TopologySegment, OpennmsModelProtos.TopologySegment.Builder, OpennmsModelProtos.TopologySegmentOrBuilder> targetSegmentBuilder_;
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public boolean hasTargetSegment() {
-        return targetCase_ == 4;
+        return targetCase_ == 7;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public OpennmsModelProtos.TopologySegment getTargetSegment() {
         if (targetSegmentBuilder_ == null) {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             return (OpennmsModelProtos.TopologySegment) target_;
           }
           return OpennmsModelProtos.TopologySegment.getDefaultInstance();
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             return targetSegmentBuilder_.getMessage();
           }
           return OpennmsModelProtos.TopologySegment.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder setTargetSegment(OpennmsModelProtos.TopologySegment value) {
         if (targetSegmentBuilder_ == null) {
@@ -19474,11 +20091,11 @@ public final class OpennmsModelProtos {
         } else {
           targetSegmentBuilder_.setMessage(value);
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder setTargetSegment(
           OpennmsModelProtos.TopologySegment.Builder builderForValue) {
@@ -19488,15 +20105,15 @@ public final class OpennmsModelProtos {
         } else {
           targetSegmentBuilder_.setMessage(builderForValue.build());
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder mergeTargetSegment(OpennmsModelProtos.TopologySegment value) {
         if (targetSegmentBuilder_ == null) {
-          if (targetCase_ == 4 &&
+          if (targetCase_ == 7 &&
               target_ != OpennmsModelProtos.TopologySegment.getDefaultInstance()) {
             target_ = OpennmsModelProtos.TopologySegment.newBuilder((OpennmsModelProtos.TopologySegment) target_)
                 .mergeFrom(value).buildPartial();
@@ -19505,26 +20122,26 @@ public final class OpennmsModelProtos {
           }
           onChanged();
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             targetSegmentBuilder_.mergeFrom(value);
           }
           targetSegmentBuilder_.setMessage(value);
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder clearTargetSegment() {
         if (targetSegmentBuilder_ == null) {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             targetCase_ = 0;
             target_ = null;
             onChanged();
           }
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             targetCase_ = 0;
             target_ = null;
           }
@@ -19533,32 +20150,32 @@ public final class OpennmsModelProtos {
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public OpennmsModelProtos.TopologySegment.Builder getTargetSegmentBuilder() {
         return getTargetSegmentFieldBuilder().getBuilder();
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public OpennmsModelProtos.TopologySegmentOrBuilder getTargetSegmentOrBuilder() {
-        if ((targetCase_ == 4) && (targetSegmentBuilder_ != null)) {
+        if ((targetCase_ == 7) && (targetSegmentBuilder_ != null)) {
           return targetSegmentBuilder_.getMessageOrBuilder();
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             return (OpennmsModelProtos.TopologySegment) target_;
           }
           return OpennmsModelProtos.TopologySegment.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           OpennmsModelProtos.TopologySegment, OpennmsModelProtos.TopologySegment.Builder, OpennmsModelProtos.TopologySegmentOrBuilder> 
           getTargetSegmentFieldBuilder() {
         if (targetSegmentBuilder_ == null) {
-          if (!(targetCase_ == 4)) {
+          if (!(targetCase_ == 7)) {
             target_ = OpennmsModelProtos.TopologySegment.getDefaultInstance();
           }
           targetSegmentBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
@@ -19568,9 +20185,145 @@ public final class OpennmsModelProtos {
                   isClean());
           target_ = null;
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         onChanged();;
         return targetSegmentBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          OpennmsModelProtos.Node, OpennmsModelProtos.Node.Builder, OpennmsModelProtos.NodeOrBuilder> targetNodeBuilder_;
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public boolean hasTargetNode() {
+        return targetCase_ == 8;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public OpennmsModelProtos.Node getTargetNode() {
+        if (targetNodeBuilder_ == null) {
+          if (targetCase_ == 8) {
+            return (OpennmsModelProtos.Node) target_;
+          }
+          return OpennmsModelProtos.Node.getDefaultInstance();
+        } else {
+          if (targetCase_ == 8) {
+            return targetNodeBuilder_.getMessage();
+          }
+          return OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder setTargetNode(OpennmsModelProtos.Node value) {
+        if (targetNodeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          target_ = value;
+          onChanged();
+        } else {
+          targetNodeBuilder_.setMessage(value);
+        }
+        targetCase_ = 8;
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder setTargetNode(
+          OpennmsModelProtos.Node.Builder builderForValue) {
+        if (targetNodeBuilder_ == null) {
+          target_ = builderForValue.build();
+          onChanged();
+        } else {
+          targetNodeBuilder_.setMessage(builderForValue.build());
+        }
+        targetCase_ = 8;
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder mergeTargetNode(OpennmsModelProtos.Node value) {
+        if (targetNodeBuilder_ == null) {
+          if (targetCase_ == 8 &&
+              target_ != OpennmsModelProtos.Node.getDefaultInstance()) {
+            target_ = OpennmsModelProtos.Node.newBuilder((OpennmsModelProtos.Node) target_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            target_ = value;
+          }
+          onChanged();
+        } else {
+          if (targetCase_ == 8) {
+            targetNodeBuilder_.mergeFrom(value);
+          }
+          targetNodeBuilder_.setMessage(value);
+        }
+        targetCase_ = 8;
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder clearTargetNode() {
+        if (targetNodeBuilder_ == null) {
+          if (targetCase_ == 8) {
+            targetCase_ = 0;
+            target_ = null;
+            onChanged();
+          }
+        } else {
+          if (targetCase_ == 8) {
+            targetCase_ = 0;
+            target_ = null;
+          }
+          targetNodeBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public OpennmsModelProtos.Node.Builder getTargetNodeBuilder() {
+        return getTargetNodeFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public OpennmsModelProtos.NodeOrBuilder getTargetNodeOrBuilder() {
+        if ((targetCase_ == 8) && (targetNodeBuilder_ != null)) {
+          return targetNodeBuilder_.getMessageOrBuilder();
+        } else {
+          if (targetCase_ == 8) {
+            return (OpennmsModelProtos.Node) target_;
+          }
+          return OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          OpennmsModelProtos.Node, OpennmsModelProtos.Node.Builder, OpennmsModelProtos.NodeOrBuilder> 
+          getTargetNodeFieldBuilder() {
+        if (targetNodeBuilder_ == null) {
+          if (!(targetCase_ == 8)) {
+            target_ = OpennmsModelProtos.Node.getDefaultInstance();
+          }
+          targetNodeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              OpennmsModelProtos.Node, OpennmsModelProtos.Node.Builder, OpennmsModelProtos.NodeOrBuilder>(
+                  (OpennmsModelProtos.Node) target_,
+                  getParentForChildren(),
+                  isClean());
+          target_ = null;
+        }
+        targetCase_ = 8;
+        onChanged();;
+        return targetNodeBuilder_;
       }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -19758,23 +20511,27 @@ public final class OpennmsModelProtos {
       "ys_description\030\t \001(\t\022\025\n\rsys_object_id\030\n " +
       "\001(\t\022\"\n\014ip_interface\030\013 \003(\0132\014.IpInterface\022" +
       "&\n\016snmp_interface\030\014 \003(\0132\016.SnmpInterface\022" +
-      "\037\n\014hw_inventory\030\r \001(\0132\t.HwEntity\"\201\001\n\013Top" +
+      "\037\n\014hw_inventory\030\r \001(\0132\t.HwEntity\"\222\001\n\013Top" +
       "ologyRef\022\n\n\002id\030\001 \001(\t\022\'\n\010protocol\030\002 \001(\0162\025" +
-      ".TopologyRef.Protocol\"=\n\010Protocol\022\010\n\004LLD" +
+      ".TopologyRef.Protocol\"N\n\010Protocol\022\010\n\004LLD" +
       "P\020\000\022\010\n\004OSPF\020\001\022\010\n\004ISIS\020\002\022\n\n\006BRIDGE\020\003\022\007\n\003C" +
-      "DP\020\004\",\n\017TopologySegment\022\031\n\003ref\030\001 \001(\0132\014.T" +
-      "opologyRef\"{\n\014TopologyPort\022\021\n\tvertex_id\030" +
-      "\001 \001(\t\022\020\n\010if_index\030\002 \001(\004\022\017\n\007if_name\030\003 \001(\t" +
-      "\022\017\n\007address\030\004 \001(\t\022$\n\rnode_criteria\030\005 \001(\013" +
-      "2\r.NodeCriteria\"\242\001\n\014TopologyEdge\022\031\n\003ref\030" +
-      "\001 \001(\0132\014.TopologyRef\022\035\n\006source\030\002 \001(\0132\r.To" +
-      "pologyPort\022#\n\ntargetPort\030\003 \001(\0132\r.Topolog" +
-      "yPortH\000\022)\n\rtargetSegment\030\004 \001(\0132\020.Topolog" +
-      "ySegmentH\000B\010\n\006target*g\n\010Severity\022\021\n\rINDE" +
-      "TERMINATE\020\000\022\013\n\007CLEARED\020\001\022\n\n\006NORMAL\020\002\022\013\n\007" +
-      "WARNING\020\003\022\t\n\005MINOR\020\004\022\t\n\005MAJOR\020\005\022\014\n\010CRITI" +
-      "CAL\020\006B>\n(org.opennms.oce.datasource.open" +
-      "nms.protoB\022OpennmsModelProtosb\006proto3"
+      "DP\020\004\022\017\n\013USERDEFINED\020\005\",\n\017TopologySegment" +
+      "\022\031\n\003ref\030\001 \001(\0132\014.TopologyRef\"{\n\014TopologyP" +
+      "ort\022\021\n\tvertex_id\030\001 \001(\t\022\020\n\010if_index\030\002 \001(\004" +
+      "\022\017\n\007if_name\030\003 \001(\t\022\017\n\007address\030\004 \001(\t\022$\n\rno" +
+      "de_criteria\030\005 \001(\0132\r.NodeCriteria\"\227\002\n\014Top" +
+      "ologyEdge\022\031\n\003ref\030\001 \001(\0132\014.TopologyRef\022#\n\n" +
+      "sourcePort\030\003 \001(\0132\r.TopologyPortH\000\022)\n\rsou" +
+      "rceSegment\030\004 \001(\0132\020.TopologySegmentH\000\022\033\n\n" +
+      "sourceNode\030\005 \001(\0132\005.NodeH\000\022#\n\ntargetPort\030" +
+      "\006 \001(\0132\r.TopologyPortH\001\022)\n\rtargetSegment\030" +
+      "\007 \001(\0132\020.TopologySegmentH\001\022\033\n\ntargetNode\030" +
+      "\010 \001(\0132\005.NodeH\001B\010\n\006sourceB\010\n\006target*g\n\010Se" +
+      "verity\022\021\n\rINDETERMINATE\020\000\022\013\n\007CLEARED\020\001\022\n" +
+      "\n\006NORMAL\020\002\022\013\n\007WARNING\020\003\022\t\n\005MINOR\020\004\022\t\n\005MA" +
+      "JOR\020\005\022\014\n\010CRITICAL\020\006B>\n(org.opennms.oce.d" +
+      "atasource.opennms.protoB\022OpennmsModelPro" +
+      "tosb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -19871,7 +20628,7 @@ public final class OpennmsModelProtos {
     internal_static_TopologyEdge_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_TopologyEdge_descriptor,
-        new java.lang.String[] { "Ref", "Source", "TargetPort", "TargetSegment", "Target", });
+        new java.lang.String[] { "Ref", "SourcePort", "SourceSegment", "SourceNode", "TargetPort", "TargetSegment", "TargetNode", "Source", "Target", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/datasource/opennms-kafka/src/main/proto/opennms-kafka-producer.proto
+++ b/datasource/opennms-kafka/src/main/proto/opennms-kafka-producer.proto
@@ -157,6 +157,7 @@ message TopologyRef {
         ISIS = 2;
         BRIDGE = 3;
         CDP = 4;
+        USERDEFINED = 5;
     }
     Protocol protocol = 2;
 }
@@ -175,9 +176,14 @@ message TopologyPort {
 
 message TopologyEdge {
     TopologyRef ref = 1;
-    TopologyPort source = 2;
+    oneof source {
+        TopologyPort sourcePort = 3;
+        TopologySegment sourceSegment = 4;
+        Node sourceNode = 5;
+    }
     oneof target {
-        TopologyPort targetPort = 3;
-        TopologySegment targetSegment = 4;
+        TopologyPort targetPort = 6;
+        TopologySegment targetSegment = 7;
+        Node targetNode = 8;
     }
 }

--- a/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/datasource/opennms-kafka/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,7 +17,7 @@
         </cm:default-properties>
     </cm:property-placeholder>
 
-    <bean id="scriptService" class="org.opennms.oce.datasource.opennms.ScriptedInventoryImpl">
+    <bean id="scriptService" class="org.opennms.oce.datasource.opennms.OpennmsKafkaScriptedInventory">
         <argument value="${scriptFile}"/>
         <argument value="${scriptCacheMillis}"/>
         <argument ref="blueprintBundleContext"/>

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/EdgeToInventoryTest.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/EdgeToInventoryTest.java
@@ -31,37 +31,28 @@ package org.opennms.oce.datasource.opennms;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.opennms.oce.datasource.opennms.EdgeToInventory.getIdForEdge;
 
-import java.util.Collections;
-
-import org.hamcrest.Matchers;
-import org.junit.Before;
 import org.junit.Test;
-import org.opennms.oce.datasource.api.InventoryObject;
-import org.opennms.oce.datasource.api.InventoryObjectPeerEndpoint;
+import org.opennms.oce.datasource.common.inventory.Edge;
 import org.opennms.oce.datasource.common.inventory.ManagedObjectType;
-import org.opennms.oce.datasource.common.inventory.Port;
 import org.opennms.oce.datasource.common.inventory.Segment;
-import org.opennms.oce.datasource.opennms.processors.InventoryTableProcessor;
 import org.opennms.oce.datasource.opennms.proto.InventoryModelProtos;
 import org.opennms.oce.datasource.opennms.proto.OpennmsModelProtos;
 
 public class EdgeToInventoryTest {
     private static final OpennmsModelProtos.TopologyRef.Protocol DEFAULT_PROTOCOL =
             OpennmsModelProtos.TopologyRef.Protocol.CDP;
-    private final ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+    private final ScriptedInventoryService inventoryService = OpennmsKafkaScriptedInventory.withDefaults();
     private final EdgeToInventory edgeToInventory = new EdgeToInventory(inventoryService);
 
     @Test
-    public void canMapEdgeToInventory() {
+    public void canMapPortToPortEdgeToInventory() {
         OpennmsModelProtos.TopologyEdge edge = OpennmsModelProtos.TopologyEdge.newBuilder()
                 .setRef(OpennmsModelProtos.TopologyRef.newBuilder()
                         .setId("id")
                         .setProtocol(DEFAULT_PROTOCOL)
                         .build())
-                .setSource(OpennmsModelProtos.TopologyPort.newBuilder()
+                .setSourcePort(OpennmsModelProtos.TopologyPort.newBuilder()
                         .setIfIndex(0)
                         .setNodeCriteria(OpennmsModelProtos.NodeCriteria.newBuilder()
                                 // The source port will have a node criteria with FS/FID/ID
@@ -81,18 +72,29 @@ public class EdgeToInventoryTest {
         InventoryModelProtos.InventoryObjects inventory = edgeToInventory.toInventoryObjects(edge);
         assertThat(inventory.getInventoryObjectList(), hasSize(1));
         InventoryModelProtos.InventoryObject io = inventory.getInventoryObjectList().iterator().next();
-        verifyLinkIo(edge, io);
+        assertThat(io.getType(), equalTo(ManagedObjectType.SnmpInterfaceLink.getName()));
+        String peerAId = null;
+        String peerZId = null;
+        for (InventoryModelProtos.InventoryObjectPeerRef inventoryObjectPeerRef : io.getPeerList()) {
+            assertThat(inventoryObjectPeerRef.getType(), equalTo(ManagedObjectType.SnmpInterface.getName()));
+            if (inventoryObjectPeerRef.getEndpoint() == InventoryModelProtos.InventoryObjectPeerEndpoint.A) {
+                peerAId = inventoryObjectPeerRef.getId();
+            } else if (inventoryObjectPeerRef.getEndpoint() == InventoryModelProtos.InventoryObjectPeerEndpoint.Z) {
+                peerZId = inventoryObjectPeerRef.getId();
+            }
+        }
+        assertThat(io.getId(), equalTo(Edge.generateId(edge.getRef().getProtocol().toString(), peerAId, peerZId)));
     }
 
     @Test
-    public void canMapEdgeWithSegmentToInventory() {
+    public void canMapPortToSegmentEdgeToInventory() {
         String segmentId = "segment.id";
         OpennmsModelProtos.TopologyEdge edge = OpennmsModelProtos.TopologyEdge.newBuilder()
                 .setRef(OpennmsModelProtos.TopologyRef.newBuilder()
                         .setId("id")
                         .setProtocol(OpennmsModelProtos.TopologyRef.Protocol.BRIDGE)
                         .build())
-                .setSource(OpennmsModelProtos.TopologyPort.newBuilder()
+                .setSourcePort(OpennmsModelProtos.TopologyPort.newBuilder()
                         .setIfIndex(0)
                         .setNodeCriteria(OpennmsModelProtos.NodeCriteria.newBuilder()
                                 // The source port will have a node criteria with FS/FID/ID
@@ -115,11 +117,21 @@ public class EdgeToInventoryTest {
         boolean verifiedSegment = false;
         for (InventoryModelProtos.InventoryObject io : inventory.getInventoryObjectList()) {
             if (io.getType().equals(ManagedObjectType.BridgeLink.getName())) {
-                assertThat(io.getType(), is(Matchers.equalTo(ManagedObjectType.BridgeLink.getName())));
+                assertThat(io.getType(), equalTo(ManagedObjectType.BridgeLink.getName()));
                 assertThat(io.getPeerList(), hasSize(2));
-                assertThat(io.getId(), is(Matchers.equalTo(getIdForEdge(edge))));
+                String peerAId = null;
+                String peerZId = null;
+                for (InventoryModelProtos.InventoryObjectPeerRef inventoryObjectPeerRef : io.getPeerList()) {
+                    if (inventoryObjectPeerRef.getEndpoint() == InventoryModelProtos.InventoryObjectPeerEndpoint.A) {
+                        peerAId = inventoryObjectPeerRef.getId();
+                    } else if (inventoryObjectPeerRef.getEndpoint() == InventoryModelProtos.InventoryObjectPeerEndpoint.Z) {
+                        peerZId = inventoryObjectPeerRef.getId();
+                    }
+                }
+                assertThat(io.getId(), equalTo(Edge.generateId(OpennmsModelProtos.TopologyRef.Protocol.BRIDGE.name(),
+                        peerAId, peerZId)));
                 verifiedLink = true;
-            } else if (io.getType().equals(ManagedObjectType.Segment.getName())) {
+            } else if (io.getType().equals(ManagedObjectType.BridgeSegment.getName())) {
                 assertThat(io.getId(), equalTo(Segment.generateId(segmentId,
                         OpennmsModelProtos.TopologyRef.Protocol.BRIDGE.name())));
                 verifiedSegment = true;
@@ -128,33 +140,4 @@ public class EdgeToInventoryTest {
         assertThat(verifiedLink, equalTo(true));
         assertThat(verifiedSegment, equalTo(true));
     }
-
-    private static void verifyLinkIo(OpennmsModelProtos.TopologyEdge edge, InventoryModelProtos.InventoryObject io) {
-        InventoryModelProtos.InventoryObjects inventoryObjects =
-                InventoryModelProtos.InventoryObjects.newBuilder().addInventoryObject(io).build();
-        verifyLinkIo(edge,
-                InventoryTableProcessor.toInventory(Collections.singletonList(inventoryObjects)).iterator().next());
-    }
-
-    public static void verifyLinkIo(OpennmsModelProtos.TopologyEdge edge, InventoryObject io) {
-        assertThat(io.getType(), is(Matchers.equalTo(ManagedObjectType.SnmpInterfaceLink.getName())));
-        assertThat(io.getPeers(), hasSize(2));
-        assertThat(io.getId(), is(Matchers.equalTo(getIdForEdge(edge))));
-
-        long aIfIndex = edge.getSource().getIfIndex();
-        long zIfIndex = edge.getTargetPort().getIfIndex();
-
-        io.getPeers().forEach(peer -> {
-            assertThat(peer.getType(), is(Matchers.equalTo(ManagedObjectType.SnmpInterface.getName())));
-            if (peer.getEndpoint() == InventoryObjectPeerEndpoint.A) {
-                assertThat(peer.getId(), is(Matchers.equalTo(Port.generateId(aIfIndex,
-                        OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()), DEFAULT_PROTOCOL.name()))));
-            } else if (peer.getEndpoint() == InventoryObjectPeerEndpoint.Z) {
-                assertThat(peer.getId(), is(Matchers.equalTo(Port.generateId(zIfIndex,
-                        OpennmsMapper.toNodeCriteria(edge.getTargetPort().getNodeCriteria()),
-                        DEFAULT_PROTOCOL.name()))));
-            }
-        });
-    }
-
 }

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/EdgeToInventoryTest.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/EdgeToInventoryTest.java
@@ -29,8 +29,10 @@
 package org.opennms.oce.datasource.opennms;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.opennms.oce.datasource.opennms.EdgeToInventory.getIdForEdge;
 
 import java.util.Collections;
 
@@ -40,25 +42,24 @@ import org.junit.Test;
 import org.opennms.oce.datasource.api.InventoryObject;
 import org.opennms.oce.datasource.api.InventoryObjectPeerEndpoint;
 import org.opennms.oce.datasource.common.inventory.ManagedObjectType;
+import org.opennms.oce.datasource.common.inventory.Port;
+import org.opennms.oce.datasource.common.inventory.Segment;
 import org.opennms.oce.datasource.opennms.processors.InventoryTableProcessor;
 import org.opennms.oce.datasource.opennms.proto.InventoryModelProtos;
 import org.opennms.oce.datasource.opennms.proto.OpennmsModelProtos;
 
 public class EdgeToInventoryTest {
-    private EdgeToInventory edgeToInventory;
-
-    @Before
-    public void setup() {
-        ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
-        edgeToInventory = new EdgeToInventory(inventoryService);
-    }
+    private static final OpennmsModelProtos.TopologyRef.Protocol DEFAULT_PROTOCOL =
+            OpennmsModelProtos.TopologyRef.Protocol.CDP;
+    private final ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+    private final EdgeToInventory edgeToInventory = new EdgeToInventory(inventoryService);
 
     @Test
     public void canMapEdgeToInventory() {
         OpennmsModelProtos.TopologyEdge edge = OpennmsModelProtos.TopologyEdge.newBuilder()
                 .setRef(OpennmsModelProtos.TopologyRef.newBuilder()
                         .setId("id")
-                        .setProtocol(OpennmsModelProtos.TopologyRef.Protocol.CDP)
+                        .setProtocol(DEFAULT_PROTOCOL)
                         .build())
                 .setSource(OpennmsModelProtos.TopologyPort.newBuilder()
                         .setIfIndex(0)
@@ -83,7 +84,52 @@ public class EdgeToInventoryTest {
         verifyLinkIo(edge, io);
     }
 
-    void verifyLinkIo(OpennmsModelProtos.TopologyEdge edge, InventoryModelProtos.InventoryObject io) {
+    @Test
+    public void canMapEdgeWithSegmentToInventory() {
+        String segmentId = "segment.id";
+        OpennmsModelProtos.TopologyEdge edge = OpennmsModelProtos.TopologyEdge.newBuilder()
+                .setRef(OpennmsModelProtos.TopologyRef.newBuilder()
+                        .setId("id")
+                        .setProtocol(OpennmsModelProtos.TopologyRef.Protocol.BRIDGE)
+                        .build())
+                .setSource(OpennmsModelProtos.TopologyPort.newBuilder()
+                        .setIfIndex(0)
+                        .setNodeCriteria(OpennmsModelProtos.NodeCriteria.newBuilder()
+                                // The source port will have a node criteria with FS/FID/ID
+                                .setForeignSource("aFS")
+                                .setForeignId("aFID")
+                                .setId(1)
+                                .build())
+                        .build())
+                .setTargetSegment(OpennmsModelProtos.TopologySegment.newBuilder()
+                        .setRef(OpennmsModelProtos.TopologyRef.newBuilder()
+                                .setId(segmentId)
+                                .setProtocol(OpennmsModelProtos.TopologyRef.Protocol.BRIDGE)
+                                .build())
+                        .build())
+                .build();
+        InventoryModelProtos.InventoryObjects inventory = edgeToInventory.toInventoryObjects(edge);
+        // Expect two inventory, a segment and an edge
+        assertThat(inventory.getInventoryObjectList(), hasSize(2));
+        boolean verifiedLink = false;
+        boolean verifiedSegment = false;
+        for (InventoryModelProtos.InventoryObject io : inventory.getInventoryObjectList()) {
+            if (io.getType().equals(ManagedObjectType.BridgeLink.getName())) {
+                assertThat(io.getType(), is(Matchers.equalTo(ManagedObjectType.BridgeLink.getName())));
+                assertThat(io.getPeerList(), hasSize(2));
+                assertThat(io.getId(), is(Matchers.equalTo(getIdForEdge(edge))));
+                verifiedLink = true;
+            } else if (io.getType().equals(ManagedObjectType.Segment.getName())) {
+                assertThat(io.getId(), equalTo(Segment.generateId(segmentId,
+                        OpennmsModelProtos.TopologyRef.Protocol.BRIDGE.name())));
+                verifiedSegment = true;
+            }
+        }
+        assertThat(verifiedLink, equalTo(true));
+        assertThat(verifiedSegment, equalTo(true));
+    }
+
+    private static void verifyLinkIo(OpennmsModelProtos.TopologyEdge edge, InventoryModelProtos.InventoryObject io) {
         InventoryModelProtos.InventoryObjects inventoryObjects =
                 InventoryModelProtos.InventoryObjects.newBuilder().addInventoryObject(io).build();
         verifyLinkIo(edge,
@@ -93,20 +139,20 @@ public class EdgeToInventoryTest {
     public static void verifyLinkIo(OpennmsModelProtos.TopologyEdge edge, InventoryObject io) {
         assertThat(io.getType(), is(Matchers.equalTo(ManagedObjectType.SnmpInterfaceLink.getName())));
         assertThat(io.getPeers(), hasSize(2));
-        assertThat(io.getId(), is(Matchers.equalTo(EdgeToInventory.getIdForEdge(edge))));
+        assertThat(io.getId(), is(Matchers.equalTo(getIdForEdge(edge))));
 
         long aIfIndex = edge.getSource().getIfIndex();
         long zIfIndex = edge.getTargetPort().getIfIndex();
 
-        // Note: needs to be updated for segments
         io.getPeers().forEach(peer -> {
             assertThat(peer.getType(), is(Matchers.equalTo(ManagedObjectType.SnmpInterface.getName())));
             if (peer.getEndpoint() == InventoryObjectPeerEndpoint.A) {
-                assertThat(peer.getId(), is(Matchers.equalTo(String.format("%s:%d",
-                        OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()), aIfIndex))));
+                assertThat(peer.getId(), is(Matchers.equalTo(Port.generateId(aIfIndex,
+                        OpennmsMapper.toNodeCriteria(edge.getSource().getNodeCriteria()), DEFAULT_PROTOCOL.name()))));
             } else if (peer.getEndpoint() == InventoryObjectPeerEndpoint.Z) {
-                assertThat(peer.getId(), is(Matchers.equalTo(String.format("%s:%d",
-                        OpennmsMapper.toNodeCriteria(edge.getTargetPort().getNodeCriteria()), zIfIndex))));
+                assertThat(peer.getId(), is(Matchers.equalTo(Port.generateId(zIfIndex,
+                        OpennmsMapper.toNodeCriteria(edge.getTargetPort().getNodeCriteria()),
+                        DEFAULT_PROTOCOL.name()))));
             }
         });
     }

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/MockNetwork.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/MockNetwork.java
@@ -211,17 +211,17 @@ public class MockNetwork {
         return builder.build();
     }
 
-    public static OpennmsModelProtos.TopologyEdge createEdgeFor(OpennmsModelProtos.TopologyRef.Protocol protocol,
-                                                                String id,
-                                                                OpennmsModelProtos.NodeCriteria sourceNodeCriteria,
-                                                                OpennmsModelProtos.NodeCriteria targetNodeCriteria,
-                                                                long ifIndex) {
+    public static OpennmsModelProtos.TopologyEdge createPortToPortEdgeFor(OpennmsModelProtos.TopologyRef.Protocol protocol,
+                                                                          String id,
+                                                                          OpennmsModelProtos.NodeCriteria sourceNodeCriteria,
+                                                                          OpennmsModelProtos.NodeCriteria targetNodeCriteria,
+                                                                          long ifIndex) {
         OpennmsModelProtos.TopologyEdge edge = OpennmsModelProtos.TopologyEdge.newBuilder()
                 .setRef(OpennmsModelProtos.TopologyRef.newBuilder()
                         .setId(id)
                         .setProtocol(protocol)
                         .build())
-                .setSource(OpennmsModelProtos.TopologyPort.newBuilder()
+                .setSourcePort(OpennmsModelProtos.TopologyPort.newBuilder()
                         .setIfIndex(ifIndex)
                         .setNodeCriteria(sourceNodeCriteria)
                         .build())

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/NodeToInventoryTest.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/NodeToInventoryTest.java
@@ -46,7 +46,7 @@ public class NodeToInventoryTest {
 
     @Before
     public void setUp() {
-        ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+        ScriptedInventoryService inventoryService = OpennmsKafkaScriptedInventory.withDefaults();
         nodeToInventory = new NodeToInventory(inventoryService);
     }
 

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsAlarmDatasourceIT.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsAlarmDatasourceIT.java
@@ -116,7 +116,7 @@ public class OpennmsAlarmDatasourceIT extends OpennmsDatasourceIT implements Ala
         // Stop & restart
         datasource.destroy();
         // (Re)create the datasource
-        ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+        ScriptedInventoryService inventoryService = OpennmsKafkaScriptedInventory.withDefaults();
         NodeToInventory nodeToInventory = new NodeToInventory(inventoryService);
         AlarmToInventory alarmToInventory = new AlarmToInventory(inventoryService);
         EdgeToInventory edgeToInventory = new EdgeToInventory(inventoryService);

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsAlarmFeedbackDatasourceIT.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsAlarmFeedbackDatasourceIT.java
@@ -114,7 +114,7 @@ public class OpennmsAlarmFeedbackDatasourceIT extends OpennmsDatasourceIT implem
         // Stop & restart
         datasource.destroy();
         // (Re)create the datasource
-        ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+        ScriptedInventoryService inventoryService = OpennmsKafkaScriptedInventory.withDefaults();
         NodeToInventory nodeToInventory = new NodeToInventory(inventoryService);
         AlarmToInventory alarmToInventory = new AlarmToInventory(inventoryService);
         EdgeToInventory edgeToInventory = new EdgeToInventory(inventoryService);

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsDatasourceIT.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsDatasourceIT.java
@@ -74,7 +74,7 @@ public abstract class OpennmsDatasourceIT {
         producer = new KafkaProducer<>(senderProps);
 
         // Create the datasource
-        ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+        ScriptedInventoryService inventoryService = OpennmsKafkaScriptedInventory.withDefaults();
         NodeToInventory nodeToInventory = new NodeToInventory(inventoryService);
         AlarmToInventory alarmToInventory = new AlarmToInventory(inventoryService);
         EdgeToInventory edgeToInventory = new EdgeToInventory(inventoryService);

--- a/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsDatasourceStoreTest.java
+++ b/datasource/opennms-kafka/src/test/java/org/opennms/oce/datasource/opennms/OpennmsDatasourceStoreTest.java
@@ -80,7 +80,7 @@ public class OpennmsDatasourceStoreTest {
         long step = 10000L;
 
         ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class, RETURNS_DEEP_STUBS);
-        ScriptedInventoryService inventoryService = new ScriptedInventoryImpl("src/main/resources/inventory.groovy");
+        ScriptedInventoryService inventoryService = OpennmsKafkaScriptedInventory.withDefaults();
         NodeToInventory nodeToInventory = new NodeToInventory(inventoryService);
         AlarmToInventory alarmToInventory = new AlarmToInventory(inventoryService);
         EdgeToInventory edgeToInventory = new EdgeToInventory(inventoryService);

--- a/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/GraphManager.java
+++ b/engine/cluster/src/main/java/org/opennms/oce/engine/cluster/GraphManager.java
@@ -243,6 +243,8 @@ public class GraphManager {
             final ResourceKey resourceKey = getResourceKeyFor(io);
             final CEVertex vertex = resourceKeyVertexMap.remove(resourceKey);
             if (vertex != null) {
+                // When a vertex that is referenced by edges is removed, the referencing edges are also removed
+                // automatically
                 g.removeVertex(vertex);
                 didGraphChange.set(true);
             }

--- a/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/GraphManagerTest.java
+++ b/engine/cluster/src/test/java/org/opennms/oce/engine/cluster/GraphManagerTest.java
@@ -47,7 +47,6 @@ import org.opennms.oce.datasource.api.Severity;
 import org.opennms.oce.datasource.common.ImmutableAlarm;
 import org.opennms.oce.datasource.common.ImmutableInventoryObject;
 import org.opennms.oce.datasource.common.ImmutableInventoryObjectPeerRef;
-import org.opennms.oce.datasource.common.inventory.Edge;
 import org.opennms.oce.datasource.common.inventory.ManagedObjectType;
 import org.opennms.oce.datasource.common.inventory.Segment;
 import org.opennms.oce.driver.test.MockAlarmBuilder;
@@ -411,7 +410,7 @@ public class GraphManagerTest {
         // Create a segment
         InventoryObject segment = ImmutableInventoryObject.newBuilder()
                 .setId(Segment.generateId("s1", "protocol"))
-                .setType(ManagedObjectType.Segment.getName())
+                .setType(ManagedObjectType.BridgeSegment.getName())
                 .build();
         
         // Create a link between the segment and node 1 interface
@@ -425,7 +424,7 @@ public class GraphManagerTest {
                         .build())
                 .addPeer(ImmutableInventoryObjectPeerRef.newBuilder()
                         .setId(Segment.generateId("s1", "protocol"))
-                        .setType(ManagedObjectType.Segment.getName())
+                        .setType(ManagedObjectType.BridgeSegment.getName())
                         .setEndpoint(InventoryObjectPeerEndpoint.Z)
                         .build())
                 .build();

--- a/integrations/opennms/config/pom.xml
+++ b/integrations/opennms/config/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.opennms.integration.api</groupId>
-            <artifactId>xml</artifactId>
+            <artifactId>config</artifactId>
 	    <version>${opennms.api.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <okhttp.version>3.10.0</okhttp.version>
         <okio.bundle.version>1.14.0_1</okio.bundle.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
-        <opennms.api.version>1.0.0-alpha3-SNAPSHOT</opennms.api.version>
+        <opennms.api.version>1.0.0-alpha8-SNAPSHOT</opennms.api.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <protobuf.version>3.5.1</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <okhttp.version>3.10.0</okhttp.version>
         <okio.bundle.version>1.14.0_1</okio.bundle.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
-        <opennms.api.version>1.0.0-alpha8-SNAPSHOT</opennms.api.version>
+        <opennms.api.version>1.0.0-alpha9-SNAPSHOT</opennms.api.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <protobuf.version>3.5.1</protobuf.version>


### PR DESCRIPTION
- Added support to the direct inventory data source for consuming link data from OpenNMS

Tested manually using the topology generator shell command.

This depends on the integration API changes here: https://github.com/OpenNMS/opennms-integration-api/pull/10

Jira: https://issues.opennms.org/browse/OCE-55